### PR TITLE
Generate subprojects

### DIFF
--- a/dbt_meshify/dbt_meshify.py
+++ b/dbt_meshify/dbt_meshify.py
@@ -1,3 +1,2 @@
-
-
+# TODO add the logic for each meshify command to independent tasks here to make cli thinner
 

--- a/dbt_meshify/dbt_projects.py
+++ b/dbt_meshify/dbt_projects.py
@@ -22,8 +22,9 @@ class LocalDbtProject:
         self.manifest = self.get_project_manifest()
         self.subprojects = []
     
-    def path_to_project(self) -> str:
-        return os.getcwd() + '/' + self.relative_path_to_project
+    @property
+    def path(self) -> os.Pathlike:
+        return os.path.join(os.getcwd(), self.relative_path_to_project)
 
     def dbt_operation(self, operation: List[str]) -> dbtRunnerResult:
         start_wd = os.getcwd()

--- a/dbt_meshify/dbt_projects.py
+++ b/dbt_meshify/dbt_projects.py
@@ -38,7 +38,7 @@ class LocalDbtProject:
             return manifest_result.result
         
     def get_subproject_resources(self, subproject_selector: str) -> List[str]:
-        ls_results = self.dbt_operation(["--quiet", "ls", "-s", subproject_selector])
+        ls_results = self.dbt_operation(["--log-level", "none", "ls", "-s", subproject_selector])
         if ls_results.success:
             return ls_results.result
         
@@ -105,7 +105,7 @@ class LocalDbtProject:
         """
         Returns true if this project depends on the other project as a package or via shared metadata
         """
-        return self.installs(other) or self.shared_source_metadata(other)
+        return self.installs(other) or self.shares_source_metadata(other)
 
 
 

--- a/dbt_meshify/dbt_projects.py
+++ b/dbt_meshify/dbt_projects.py
@@ -20,7 +20,7 @@ class LocalDbtProject:
     def __init__(self, relative_path_to_project: str) -> None:
         self.relative_path_to_project = relative_path_to_project
         self.manifest = self.get_project_manifest()
-        self.subproject_selectors = []
+        self.subprojects = []
     
     def path_to_project(self) -> str:
         return os.getcwd() + '/' + self.relative_path_to_project
@@ -42,12 +42,11 @@ class LocalDbtProject:
         if ls_results.success:
             return ls_results.result
         
-    def add_subproject_selector(self, subproject_selector) -> None:
-        self.subproject_selectors.append(subproject_selector)
+    def add_subproject(self, subproject_dict: Dict[str, str]) -> None:
+        self.subprojects.append(subproject_dict)
     
-    def subprojects(self) -> List[str]:
-        subprojects = {selector: self.get_subproject_resources(selector) for selector in self.subproject_selectors}
-        return subprojects
+    def update_subprojects_with_resources(self) -> List[str]:
+        [subproject.update({"resources": self.get_subproject_resources(subproject["selector"])}) for subproject in self.subprojects]
 
     def sources(self) -> Dict[str, Dict[Any, Any]]:
         return self.manifest.sources

--- a/dbt_meshify/dbt_projects.py
+++ b/dbt_meshify/dbt_projects.py
@@ -23,12 +23,12 @@ class LocalDbtProject:
         self.subprojects = []
     
     @property
-    def path(self) -> os.Pathlike:
+    def path(self) -> os.PathLike:
         return os.path.join(os.getcwd(), self.relative_path_to_project)
 
     def dbt_operation(self, operation: List[str]) -> dbtRunnerResult:
         start_wd = os.getcwd()
-        os.chdir(self.path_to_project())
+        os.chdir(self.path)
         result = dbt_runner.invoke(operation)
         os.chdir(start_wd)
         return result

--- a/dbt_meshify/dbt_projects.py
+++ b/dbt_meshify/dbt_projects.py
@@ -31,6 +31,8 @@ class LocalDbtProject:
         os.chdir(self.path)
         result = dbt_runner.invoke(operation)
         os.chdir(start_wd)
+        if not result.success:
+            raise Exception(result.exception)
         return result
     
     def get_project_manifest(self) -> Manifest:

--- a/dbt_meshify/main.py
+++ b/dbt_meshify/main.py
@@ -5,8 +5,8 @@ from .dbt_projects import LocalProjectHolder, LocalDbtProject
 def cli():
     pass
 
-@cli.command(name="merge")
-def merge():
+@cli.command(name="connect")
+def connect():
 
     holder = LocalProjectHolder()
     while True:
@@ -22,9 +22,14 @@ def split():
     path = input("Enter the relative path to a dbt project you'd like to split: ")
     project = LocalDbtProject(path)
     while True:
-        subproject_selector = input("Enter the selector that represents the subproject you'd like to create (enter 'done' to finish): ")
-        if subproject_selector == "done":
+        subproject_name = input("Enter the name for your subproject ('done' to finish): ")
+        if subproject_name == "done":
             break
-        project.add_subproject_selector(subproject_selector)
+        subproject_selector = input(f"Enter the selector that represents the subproject {subproject_name}: ")
+        project.add_subproject({
+            "name": subproject_name,
+            "selector": subproject_selector
+            })
+    project.update_subprojects_with_resources()
 
-    print(project.subprojects())
+    print(project.subprojects)

--- a/dbt_meshify/main.py
+++ b/dbt_meshify/main.py
@@ -1,5 +1,5 @@
 import click
-from .dbt_projects import LocalProjectHolder
+from .dbt_projects import LocalProjectHolder, LocalDbtProject
 
 @click.group()
 def cli():
@@ -20,9 +20,12 @@ def merge():
 
 @cli.command(name="split")
 def split():
-    holder = LocalProjectHolder()
+    path = input("Enter the relative path to a dbt project you'd like to split: ")
+    project = LocalDbtProject(path)
     while True:
-        path = input("Enter the relative path to a dbt project (enter 'done' to finish): ")
-        if path == "done":
+        subproject_selector = input("Enter the selector that represents the subproject you'd like to create (enter 'done' to finish): ")
+        if subproject_selector == "done":
             break
-        holder.add_relative_project_path(path)
+        project.add_subproject_selector(subproject_selector)
+
+    print(project.subprojects())

--- a/dbt_meshify/main.py
+++ b/dbt_meshify/main.py
@@ -5,7 +5,6 @@ from .dbt_projects import LocalProjectHolder, LocalDbtProject
 def cli():
     pass
 
-
 @cli.command(name="merge")
 def merge():
 


### PR DESCRIPTION
This updates the `split` command to take a prompt for a project name, a selector(s), and the resulting resources into a simple dictionary for later use. 

Not at all married to the design of any of it, mostly just wanted to prove out the use of the Python API to do a `dbt ls` to get the components of a subproject. 

<img width="681" alt="image" src="https://user-images.githubusercontent.com/73915542/233100085-55a33a6b-e320-494c-8153-111848f20cad.png">
