### PR TITLE
simplify cli setup

### DIFF
--- a/dbt_meshify/main.py
+++ b/dbt_meshify/main.py
@@ -6,6 +6,7 @@ from .dbt_projects import DbtProject, DbtSubProject, DbtProjectHolder
 # define common parameters
 project_path = click.option(
     "--project-path",
+    type=click.Path(exists=True),
     default="."
 )
 

--- a/dbt_meshify/main.py
+++ b/dbt_meshify/main.py
@@ -5,31 +5,29 @@ from .dbt_projects import DbtProject, DbtSubProject, DbtProjectHolder
 
 # define common parameters
 project_path = click.option(
-    "--select",
-    "-s",
-    default=None,
-    help="The dbt selection syntax specifying the resources to include in the operation"
-    )
+    "--project-path",
+    default="."
+)
 
 exclude = click.option(
     "--exclude",
     "-e",
     default=None,
     help="The dbt selection syntax specifying the resources to exclude in the operation"
-    )
+)
 
 select = click.option(
     "--select",
     "-s",
     default=None,
     help="The dbt selection syntax specifying the resources to include in the operation"
-    )
+)
 
 selector = click.option(
     "--selector",
     default=None,
     help="The name of the YML selector specifying the resources to include in the operation"
-    )
+)
 
 # define cli group 
 @click.group()
@@ -103,7 +101,7 @@ def split():
 @project_path
 @select
 @selector
-def add_contract(select, exclude, project_path):
+def add_contract(select, exclude, project_path, selector):
     """
     Adds a contract to all selected models.
     """
@@ -119,7 +117,7 @@ def add_contract(select, exclude, project_path):
 @project_path
 @select
 @selector
-def add_version(select, exclude, project_path):
+def add_version(select, exclude, project_path, selector):
     """
     Increments a model version on all selected models. Increments the version of the model if a version exists. 
     """
@@ -130,7 +128,7 @@ def add_version(select, exclude, project_path):
 @project_path
 @select
 @selector
-def create_group(select, exclude, project_path):
+def create_group(select, exclude, project_path, selector):
     """
     Add selected resources to a group
     """

--- a/dbt_meshify/main.py
+++ b/dbt_meshify/main.py
@@ -3,14 +3,48 @@ import click
 
 from .dbt_projects import DbtProject, DbtSubProject, DbtProjectHolder
 
+# define common parameters
+project_path = click.option(
+    "--select",
+    "-s",
+    default=None,
+    help="The dbt selection syntax specifying the resources to include in the operation"
+    )
 
+exclude = click.option(
+    "--exclude",
+    "-e",
+    default=None,
+    help="The dbt selection syntax specifying the resources to exclude in the operation"
+    )
+
+select = click.option(
+    "--select",
+    "-s",
+    default=None,
+    help="The dbt selection syntax specifying the resources to include in the operation"
+    )
+
+selector = click.option(
+    "--selector",
+    default=None,
+    help="The name of the YML selector specifying the resources to include in the operation"
+    )
+
+# define cli group 
 @click.group()
 def cli():
     pass
 
 
 @cli.command(name="connect")
-def connect():
+@click.argument("projects-dir", type=click.Path(exists=True), default=".")
+def connect(projects_dir):
+    """
+    Connects multiple dbt projects together by adding all necessary dbt Mesh constructs
+
+    PROJECTS_DIR: The directory containing the dbt projects to connect. Defaults to the current directory.
+    """
     holder = DbtProjectHolder()
 
     while True:
@@ -26,7 +60,20 @@ def connect():
 
 
 @cli.command(name="split")
+@exclude
+@project_path
+@select
+@selector
 def split():
+    """
+    Splits dbt projects apart by adding all necessary dbt Mesh constructs based on the selection syntax. 
+
+    Order of operations:
+    1. Regsiter the selected resources as a subproject of the main project
+    2. Add the resources to a group
+    2. Identifies the edges of the subproject with the remainder of the project
+    3. Adds contracts to all edges
+    """
     path_string = input("Enter the relative path to a dbt project you'd like to split: ")
 
     holder = DbtProjectHolder()
@@ -51,23 +98,40 @@ def split():
     print(holder.project_map())
 
 
-@cli.command(name="contract")
-@click.option(
-    "--select",
-    "-s"
-    )
-@click.option(
-    "--exclude",
-    "-e"
-    )
-@click.option(
-    "--project-path",
-    default="."
-)
-def contract(select, exclude, project_path):
+@cli.command(name="add-contract")
+@exclude
+@project_path
+@select
+@selector
+def add_contract(select, exclude, project_path):
+    """
+    Adds a contract to all selected models.
+    """
     path = Path(project_path).expanduser().resolve()
     project = DbtProject.from_directory(path)
     resources = list(project.select_resources(select=select, exclude=exclude, output_key="unique_id"))
     models = filter(lambda x: x.startswith('model'), resources)
     for model_unique_id in models:
         project.add_model_contract(model_unique_id)
+
+@cli.command(name="add-version")
+@exclude
+@project_path
+@select
+@selector
+def add_version(select, exclude, project_path):
+    """
+    Increments a model version on all selected models. Increments the version of the model if a version exists. 
+    """
+    pass
+
+@cli.command(name="create-group")
+@exclude
+@project_path
+@select
+@selector
+def create_group(select, exclude, project_path):
+    """
+    Add selected resources to a group
+    """
+    pass

--- a/tests/integration/test_contract_command.py
+++ b/tests/integration/test_contract_command.py
@@ -1,7 +1,7 @@
 from click.testing import CliRunner
 import yaml
 from pathlib import Path
-from dbt_meshify.main import contract
+from dbt_meshify.main import add_contract
 import pytest
 from ..fixtures import (
     model_yml_no_col,
@@ -41,7 +41,7 @@ def test_add_contract_to_yml(start_yml, end_yml):
         start_yml_content = yaml.safe_load(start_yml)
         with open(yml_file, 'w+') as f:
             yaml.safe_dump(start_yml_content, f, sort_keys=False)
-    result = runner.invoke(contract, ["--select", "shared_model", "--project-path", proj_path_string])
+    result = runner.invoke(add_contract, ["--select", "shared_model", "--project-path", proj_path_string])
     assert result.exit_code == 0
     # reset the read path to the default in the logic
     with open(yml_file, 'r') as f:


### PR DESCRIPTION
Closes #30

This PR cleans up the click params for 
- select
- exclude
- project-dir
- selector 

which are common for most commands. 

this also adds stubbed functions for creating groups and versions, and an argument for the `connect` command

package help:
```zsh
dbt-meshify --help
Usage: dbt-meshify [OPTIONS] COMMAND [ARGS]...

Options:
  --help  Show this message and exit.

Commands:
  add-contract  Adds a contract to all selected models.
  add-version   Increments a model version on all selected models.
  connect       Connects multiple dbt projects together by adding all...
  create-group  Add selected resources to a group
  split         Splits dbt projects apart by adding all necessary dbt...
```
command help:

```
❯ dbt-meshify add-contract --help
Usage: dbt-meshify add-contract [OPTIONS]

  Adds a contract to all selected models.

Options:
  -e, --exclude TEXT  The dbt selection syntax specifying the resources to
                      exclude in the operation
  -s, --select TEXT   The dbt selection syntax specifying the resources to
                      include in the operation
  -s, --select TEXT   The dbt selection syntax specifying the resources to
                      include in the operation
  --selector TEXT     The name of the YML selector specifying the resources to
                      include in the operation
  --help              Show this message and exit.

```
