### PR TITLE
add Precommit for isort and black

### DIFF
--- a/.github/workflows/ci-tests-pytest.yml
+++ b/.github/workflows/ci-tests-pytest.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: checkout repo
         uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,53 @@
+default_stages: [push]
+default_language_version:
+  python: python3.9
+repos:
+- repo: local
+  hooks:
+  - id: isort
+    stages: [commit,push]
+    name: isort
+    entry: poetry run isort -rc
+    language: system
+    types: [python]
+  - id: black
+    stages: [commit,push]
+    name: black
+    entry: poetry run black -S .
+    language: system
+    types: [python]
+  # - id: mypy
+  #   stages: [commit,push]
+  #   name: mypy
+  #   entry: poetry run mypy --ignore-missing-imports
+  #   language: system
+  #   types: [python]
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.1.0
+  hooks:
+  - id: trailing-whitespace
+    stages: [commit,push]
+  - id: check-added-large-files
+  - id: check-ast
+    stages: [commit,push]
+  - id: check-case-conflict
+  - id: check-byte-order-marker
+  - id: check-executables-have-shebangs
+  - id: check-docstring-first
+    stages: [commit,push]
+  - id: check-json
+  - id: check-merge-conflict
+    stages: [commit,push]
+  - id: check-symlinks
+  - id: check-vcs-permalinks
+  - id: check-xml
+  - id: check-yaml
+  - id: debug-statements
+  - id: detect-private-key
+  - id: flake8
+    stages: [commit,push]
+  - id: forbid-new-submodules
+  - id: no-commit-to-branch
+    stages: [commit,push]
+    args:
+    - --branch=main

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-default_stages: [push]
+oudefault_stages: [push]
 default_language_version:
   python: python3.9
 repos:
@@ -7,7 +7,7 @@ repos:
   - id: isort
     stages: [commit,push]
     name: isort
-    entry: poetry run isort -rc
+    entry: poetry run isort
     language: system
     types: [python]
   - id: black
@@ -44,8 +44,8 @@ repos:
   - id: check-yaml
   - id: debug-statements
   - id: detect-private-key
-  - id: flake8
-    stages: [commit,push]
+  # - id: flake8
+    # stages: [commit,push]
   - id: forbid-new-submodules
   - id: no-commit-to-branch
     stages: [commit,push]

--- a/dbt_meshify/dbt.py
+++ b/dbt_meshify/dbt.py
@@ -1,6 +1,6 @@
 # third party
 import os
-from typing import Optional, List
+from typing import List, Optional
 
 from dbt.cli.main import dbtRunner
 from dbt.contracts.graph.manifest import Manifest
@@ -27,10 +27,15 @@ class Dbt:
     def parse(self, directory: os.PathLike):
         return self.invoke(directory, ["--quiet", "parse"])
 
-    def ls(self, directory: os.PathLike, arguments: Optional[List[str]] = None, output_key: Optional[str] = None) -> List[str]:
+    def ls(
+        self,
+        directory: os.PathLike,
+        arguments: Optional[List[str]] = None,
+        output_key: Optional[str] = None,
+    ) -> List[str]:
         """
         Execute dbt ls with the given arguments and return the result as a list of strings.
-        Log level is set to none to prevent dbt from printing to stdout.    
+        Log level is set to none to prevent dbt from printing to stdout.
         """
         args = ["--log-format", "json", "--log-level", "none", "ls"]
 
@@ -40,9 +45,9 @@ class Dbt:
             args.extend(["--output", "json", "--output-keys", output_key])
 
         return self.invoke(directory, args)
-    
+
     def docs_generate(self, directory: os.PathLike) -> CatalogArtifact:
-        """ 
+        """
         Excute dbt docs generate with the given arguments
         """
         args = ["--quiet", "docs", "generate"]

--- a/dbt_meshify/dbt_meshify.py
+++ b/dbt_meshify/dbt_meshify.py
@@ -1,6 +1,8 @@
-from typing import Dict
 from collections import OrderedDict
+from typing import Dict
+
 from dbt.contracts.results import CatalogTable
+
 
 class DbtMeshYmlEditor:
     """
@@ -8,19 +10,28 @@ class DbtMeshYmlEditor:
     to add the dbt-core concepts specific to the dbt mesh
     """
 
-    def add_model_contract_to_yml(self, model_name: str, model_catalog: CatalogTable, full_yml_dict: Dict[str, str]) -> None:
+    def add_model_contract_to_yml(
+        self, model_name: str, model_catalog: CatalogTable, full_yml_dict: Dict[str, str]
+    ) -> None:
         """Adds a model contract to the model's yaml"""
         # set up yml order
-        model_ordered_dict = OrderedDict.fromkeys(["name", "description", "access", "config", "meta","columns"])
+        model_ordered_dict = OrderedDict.fromkeys(
+            ["name", "description", "access", "config", "meta", "columns"]
+        )
         # parse the yml file into a dictionary with model names as keys
-        models = { model['name']: model for model in full_yml_dict['models'] } if full_yml_dict else {}
+        models = (
+            {model["name"]: model for model in full_yml_dict["models"]} if full_yml_dict else {}
+        )
         model_yml = models.get(model_name) or {"name": model_name, "columns": [], "config": {}}
 
         # isolate the columns from the existing model entry
         yml_cols = model_yml.get("columns", [])
         catalog_cols = model_catalog.columns or {}
         # add the data type to the yml entry for columns that are in yml
-        yml_cols = [{**yml_col,'data_type' : catalog_cols.get(yml_col.get("name")).type.lower()} for yml_col in yml_cols]
+        yml_cols = [
+            {**yml_col, "data_type": catalog_cols.get(yml_col.get("name")).type.lower()}
+            for yml_col in yml_cols
+        ]
         # append missing columns in the table to the yml entry
         yml_col_names = [col.get("name").lower() for col in yml_cols]
         for col_name, col in catalog_cols.items():
@@ -30,7 +41,7 @@ class DbtMeshYmlEditor:
         model_yml.update({"columns": yml_cols})
         # add contract to the model yml entry
         # this part should come from the same service as what we use for the standalone command when we get there
-        model_yml.update({"config": {"contract": {"enforced": True }}})
+        model_yml.update({"config": {"contract": {"enforced": True}}})
         # update the model entry in the full yml file
         # if no entries exist, add the model entry
         # otherwise, update the existing model entry in place

--- a/dbt_meshify/dbt_projects.py
+++ b/dbt_meshify/dbt_projects.py
@@ -1,20 +1,20 @@
 import copy
 import hashlib
+import json
 import logging
 import os
-import json
 from pathlib import Path
-from typing import Dict, Any, Optional, MutableMapping, Set, Union
+from typing import Any, Dict, MutableMapping, Optional, Set, Union
 
 import yaml
-from dbt_meshify.file_manager import DbtFileManager
-from dbt_meshify.dbt_meshify import DbtMeshYmlEditor
 from dbt.contracts.graph.manifest import Manifest
-from dbt.contracts.graph.nodes import SourceDefinition, ModelNode, ManifestNode
+from dbt.contracts.graph.nodes import ManifestNode, ModelNode, SourceDefinition
 from dbt.contracts.project import Project
 from dbt.contracts.results import CatalogArtifact
 
 from dbt_meshify.dbt import Dbt
+from dbt_meshify.dbt_meshify import DbtMeshYmlEditor
+from dbt_meshify.file_manager import DbtFileManager
 
 logger = logging.getLogger()
 
@@ -121,6 +121,7 @@ class BaseDbtProject:
         """Returns the catalog entry for a model in the dbt project's catalog"""
         return self.manifest.nodes.get(unique_id, {})
 
+
 class DbtProject(BaseDbtProject):
     @staticmethod
     def _load_project(path) -> Project:
@@ -156,7 +157,9 @@ class DbtProject(BaseDbtProject):
         self.dbt = dbt
         self.file_manager = DbtFileManager(read_project_path=path, write_project_path=path)
 
-    def select_resources(self, select: str, exclude: Optional[str] = None, output_key: Optional[str] = None) -> Set[str]:
+    def select_resources(
+        self, select: str, exclude: Optional[str] = None, output_key: Optional[str] = None
+    ) -> Set[str]:
         """Select dbt resources using NodeSelection syntax"""
         args = []
         if select:
@@ -192,7 +195,7 @@ class DbtProject(BaseDbtProject):
 
     def add_model_contract(self, unique_id: str) -> None:
         """Adds a model contract to the model's yaml"""
-        
+
         # get the patch path for the model
         node = self.get_manifest_node(unique_id)
         yml_path = Path(node.patch_path.split("://")[1]) if node.patch_path else None
@@ -207,10 +210,8 @@ class DbtProject(BaseDbtProject):
         # pass empty dict if no file contents returned
         full_yml_dict = self.file_manager.read_file(yml_path) or {}
         updated_yml = self.meshify.add_model_contract_to_yml(
-            model_name=node.name,
-            model_catalog=model_catalog,
-            full_yml_dict=full_yml_dict
-            )
+            model_name=node.name, model_catalog=model_catalog, full_yml_dict=full_yml_dict
+        )
         # write the updated yml to the file
         self.file_manager.write_file(yml_path, updated_yml)
 

--- a/dbt_meshify/file_manager.py
+++ b/dbt_meshify/file_manager.py
@@ -3,63 +3,69 @@
 
 import os
 from abc import ABC
+from typing import Any, Dict, Optional, Union
+
 import yaml
-from typing import Dict, Any, Optional, Union
 from dbt.contracts.results import CatalogTable
 
-class BaseFileManager(ABC):
 
+class BaseFileManager(ABC):
     def read_file(path: os.PathLike) -> None:
         pass
 
     def write_file(path: os.PathLike, file_contents: Any) -> None:
         pass
 
-class YmlFileManager(BaseFileManager):
 
-    def __init__(self, 
-            read_project_path: os.PathLike, 
-            write_project_path: Optional[os.PathLike] = None) -> None:
+class YmlFileManager(BaseFileManager):
+    def __init__(
+        self, read_project_path: os.PathLike, write_project_path: Optional[os.PathLike] = None
+    ) -> None:
         self.read_project_path = read_project_path
         self.write_project_path = write_project_path if write_project_path else read_project_path
 
     def read_file(self, path: os.PathLike) -> None:
         """Returns the yaml for a model in the dbt project's manifest"""
         return yaml.load(open(os.path.join(self.read_project_path, path)), Loader=yaml.FullLoader)
-             
-    def write_file(self, path: os.PathLike, file_contents: Optional[Dict[str, str]] = None) -> None:
+
+    def write_file(
+        self, path: os.PathLike, file_contents: Optional[Dict[str, str]] = None
+    ) -> None:
         """Returns the yaml for a model in the dbt project's manifest"""
 
-        with open(os.path.join(self.write_project_path, path), 'w+') as file:
+        with open(os.path.join(self.write_project_path, path), "w+") as file:
             # Serialize the updated data back to YAML and write it to the file
             yaml.safe_dump(file_contents, file, sort_keys=False)
 
-class FileManager(BaseFileManager):
 
-    def __init__(self, 
-            read_project_path: os.PathLike, 
-            write_project_path: Optional[os.PathLike] = None) -> None:
+class FileManager(BaseFileManager):
+    def __init__(
+        self, read_project_path: os.PathLike, write_project_path: Optional[os.PathLike] = None
+    ) -> None:
         self.read_project_path = read_project_path
         self.write_project_path = write_project_path if write_project_path else read_project_path
 
     def read_file(self, path: os.PathLike) -> None:
         """Returns the yaml for a model in the dbt project's manifest"""
-        with open(os.path.join(self.read_project_path, path), 'r') as file:
+        with open(os.path.join(self.read_project_path, path), "r") as file:
             return file.read()
-             
-    def write_file(self, path: os.PathLike, file_contents: Optional[Dict[str, str]] = None) -> None:
+
+    def write_file(
+        self, path: os.PathLike, file_contents: Optional[Dict[str, str]] = None
+    ) -> None:
         """Returns the yaml for a model in the dbt project's manifest"""
 
-        with open(os.path.join(self.write_project_path, path), 'w+') as file:
+        with open(os.path.join(self.write_project_path, path), "w+") as file:
             # Serialize the updated data back to YAML and write it to the file
             file.write(file_contents)
 
 
-class DbtFileManager(): 
-
-    def __init__(self, 
-            read_project_path: Optional[os.PathLike] = None, 
-            write_project_path: Optional[os.PathLike] = None) -> None:
+class DbtFileManager:
+    def __init__(
+        self,
+        read_project_path: Optional[os.PathLike] = None,
+        write_project_path: Optional[os.PathLike] = None,
+    ) -> None:
         self.read_project_path = read_project_path
         self.write_project_path = write_project_path if write_project_path else read_project_path
         self.yml_file_manager = YmlFileManager(read_project_path, write_project_path)
@@ -67,18 +73,16 @@ class DbtFileManager():
 
     def read_file(self, path: os.PathLike) -> Union[Dict[str, str], str]:
         """Returns the yaml for a model in the dbt project's manifest"""
-        if path.suffix == '.yml':
+        if path.suffix == ".yml":
             return self.yml_file_manager.read_file(path)
         else:
             return self.base_file_manager.read_file(path)
-    
-    def write_file(self, path: os.PathLike, file_contents: Optional[Dict[str, str]] = None) -> None:
+
+    def write_file(
+        self, path: os.PathLike, file_contents: Optional[Dict[str, str]] = None
+    ) -> None:
         """Returns the yaml for a model in the dbt project's manifest"""
-        if path.suffix == '.yml':
+        if path.suffix == ".yml":
             return self.yml_file_manager.write_file(path, file_contents)
         else:
             return self.base_file_manager.write_file(path, file_contents)
-    
-
-
-

--- a/dbt_meshify/main.py
+++ b/dbt_meshify/main.py
@@ -1,36 +1,34 @@
 from pathlib import Path
+
 import click
 
-from .dbt_projects import DbtProject, DbtSubProject, DbtProjectHolder
+from .dbt_projects import DbtProject, DbtProjectHolder, DbtSubProject
 
 # define common parameters
-project_path = click.option(
-    "--project-path",
-    type=click.Path(exists=True),
-    default="."
-)
+project_path = click.option("--project-path", type=click.Path(exists=True), default=".")
 
 exclude = click.option(
     "--exclude",
     "-e",
     default=None,
-    help="The dbt selection syntax specifying the resources to exclude in the operation"
+    help="The dbt selection syntax specifying the resources to exclude in the operation",
 )
 
 select = click.option(
     "--select",
     "-s",
     default=None,
-    help="The dbt selection syntax specifying the resources to include in the operation"
+    help="The dbt selection syntax specifying the resources to include in the operation",
 )
 
 selector = click.option(
     "--selector",
     default=None,
-    help="The name of the YML selector specifying the resources to include in the operation"
+    help="The name of the YML selector specifying the resources to include in the operation",
 )
 
-# define cli group 
+
+# define cli group
 @click.group()
 def cli():
     pass
@@ -65,7 +63,7 @@ def connect(projects_dir):
 @selector
 def split():
     """
-    Splits dbt projects apart by adding all necessary dbt Mesh constructs based on the selection syntax. 
+    Splits dbt projects apart by adding all necessary dbt Mesh constructs based on the selection syntax.
 
     Order of operations:
     1. Regsiter the selected resources as a subproject of the main project
@@ -108,10 +106,13 @@ def add_contract(select, exclude, project_path, selector):
     """
     path = Path(project_path).expanduser().resolve()
     project = DbtProject.from_directory(path)
-    resources = list(project.select_resources(select=select, exclude=exclude, output_key="unique_id"))
-    models = filter(lambda x: x.startswith('model'), resources)
+    resources = list(
+        project.select_resources(select=select, exclude=exclude, output_key="unique_id")
+    )
+    models = filter(lambda x: x.startswith("model"), resources)
     for model_unique_id in models:
         project.add_model_contract(model_unique_id)
+
 
 @cli.command(name="add-version")
 @exclude
@@ -120,9 +121,10 @@ def add_contract(select, exclude, project_path, selector):
 @selector
 def add_version(select, exclude, project_path, selector):
     """
-    Increments a model version on all selected models. Increments the version of the model if a version exists. 
+    Increments a model version on all selected models. Increments the version of the model if a version exists.
     """
     pass
+
 
 @cli.command(name="create-group")
 @exclude

--- a/dbt_meshify/mesh.py
+++ b/dbt_meshify/mesh.py
@@ -132,4 +132,3 @@ class Mesh:
         dependencies.update(package_dependencies)
 
         return dependencies
-

--- a/dbt_meshify/mesh.py
+++ b/dbt_meshify/mesh.py
@@ -132,3 +132,4 @@ class Mesh:
         dependencies.update(package_dependencies)
 
         return dependencies
+

--- a/poetry.lock
+++ b/poetry.lock
@@ -59,7 +59,7 @@ files = [
 name = "black"
 version = "23.3.0"
 description = "The uncompromising code formatter."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -193,6 +193,18 @@ files = [
 
 [package.dependencies]
 pycparser = "*"
+
+[[package]]
+name = "cfgv"
+version = "3.3.1"
+description = "Validate configuration and produce human readable error messages."
+category = "main"
+optional = false
+python-versions = ">=3.6.1"
+files = [
+    {file = "cfgv-3.3.1-py2.py3-none-any.whl", hash = "sha256:c6a0883f3917a037485059700b9e75da2464e6c27051014ad85ba6aaa5884426"},
+    {file = "cfgv-3.3.1.tar.gz", hash = "sha256:f5a830efb9ce7a445376bb66ec94c638a9787422f96264c98edc6bdeed8ab736"},
+]
 
 [[package]]
 name = "charset-normalizer"
@@ -404,6 +416,18 @@ dbt-core = "1.5.0"
 psycopg2-binary = ">=2.8,<3.0"
 
 [[package]]
+name = "distlib"
+version = "0.3.6"
+description = "Distribution utilities"
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "distlib-0.3.6-py2.py3-none-any.whl", hash = "sha256:f35c4b692542ca110de7ef0bea44d73981caeb34ca0b9b6b2e6d7790dda8f80e"},
+    {file = "distlib-0.3.6.tar.gz", hash = "sha256:14bad2d9b04d3a36127ac97f30b12a19268f211063d8f8ee4f47108896e11b46"},
+]
+
+[[package]]
 name = "duckdb"
 version = "0.7.1"
 description = "DuckDB embedded database"
@@ -476,6 +500,22 @@ files = [
 test = ["pytest (>=6)"]
 
 [[package]]
+name = "filelock"
+version = "3.12.0"
+description = "A platform independent file lock."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "filelock-3.12.0-py3-none-any.whl", hash = "sha256:ad98852315c2ab702aeb628412cbf7e95b7ce8c3bf9565670b4eaecf1db370a9"},
+    {file = "filelock-3.12.0.tar.gz", hash = "sha256:fc03ae43288c013d2ea83c8597001b1129db351aad9c57fe2409327916b8e718"},
+]
+
+[package.extras]
+docs = ["furo (>=2023.3.27)", "sphinx (>=6.1.3)", "sphinx-autodoc-typehints (>=1.23,!=1.23.4)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.2.3)", "diff-cover (>=7.5)", "pytest (>=7.3.1)", "pytest-cov (>=4)", "pytest-mock (>=3.10)", "pytest-timeout (>=2.1)"]
+
+[[package]]
 name = "flake8"
 version = "6.0.0"
 description = "the modular source code checker: pep8 pyflakes and co"
@@ -520,6 +560,21 @@ jsonschema = ">=3.0"
 python-dateutil = ">=2.8,<2.9"
 
 [[package]]
+name = "identify"
+version = "2.5.24"
+description = "File identification library for Python"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "identify-2.5.24-py2.py3-none-any.whl", hash = "sha256:986dbfb38b1140e763e413e6feb44cd731faf72d1909543178aa79b0e258265d"},
+    {file = "identify-2.5.24.tar.gz", hash = "sha256:0aac67d5b4812498056d28a9a512a483f5085cc28640b02b258a59dac34301d4"},
+]
+
+[package.extras]
+license = ["ukkonen"]
+
+[[package]]
 name = "idna"
 version = "3.4"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -557,6 +612,24 @@ files = [
 
 [package.dependencies]
 six = "*"
+
+[[package]]
+name = "isort"
+version = "5.12.0"
+description = "A Python utility / library to sort Python imports."
+category = "main"
+optional = false
+python-versions = ">=3.8.0"
+files = [
+    {file = "isort-5.12.0-py3-none-any.whl", hash = "sha256:f84c2818376e66cf843d497486ea8fed8700b340f308f076c6fb1229dff318b6"},
+    {file = "isort-5.12.0.tar.gz", hash = "sha256:8bef7dde241278824a6d83f44a544709b065191b95b6e50894bdc722fcba0504"},
+]
+
+[package.extras]
+colors = ["colorama (>=0.4.3)"]
+pipfile-deprecated-finder = ["pip-shims (>=0.5.2)", "pipreqs", "requirementslib"]
+plugins = ["setuptools"]
+requirements-deprecated-finder = ["pip-api", "pipreqs"]
 
 [[package]]
 name = "jinja2"
@@ -824,10 +897,57 @@ files = [
 ]
 
 [[package]]
+name = "mypy"
+version = "1.3.0"
+description = "Optional static typing for Python"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "mypy-1.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c1eb485cea53f4f5284e5baf92902cd0088b24984f4209e25981cc359d64448d"},
+    {file = "mypy-1.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4c99c3ecf223cf2952638da9cd82793d8f3c0c5fa8b6ae2b2d9ed1e1ff51ba85"},
+    {file = "mypy-1.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:550a8b3a19bb6589679a7c3c31f64312e7ff482a816c96e0cecec9ad3a7564dd"},
+    {file = "mypy-1.3.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:cbc07246253b9e3d7d74c9ff948cd0fd7a71afcc2b77c7f0a59c26e9395cb152"},
+    {file = "mypy-1.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:a22435632710a4fcf8acf86cbd0d69f68ac389a3892cb23fbad176d1cddaf228"},
+    {file = "mypy-1.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6e33bb8b2613614a33dff70565f4c803f889ebd2f859466e42b46e1df76018dd"},
+    {file = "mypy-1.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7d23370d2a6b7a71dc65d1266f9a34e4cde9e8e21511322415db4b26f46f6b8c"},
+    {file = "mypy-1.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:658fe7b674769a0770d4b26cb4d6f005e88a442fe82446f020be8e5f5efb2fae"},
+    {file = "mypy-1.3.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:6e42d29e324cdda61daaec2336c42512e59c7c375340bd202efa1fe0f7b8f8ca"},
+    {file = "mypy-1.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:d0b6c62206e04061e27009481cb0ec966f7d6172b5b936f3ead3d74f29fe3dcf"},
+    {file = "mypy-1.3.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:76ec771e2342f1b558c36d49900dfe81d140361dd0d2df6cd71b3db1be155409"},
+    {file = "mypy-1.3.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ebc95f8386314272bbc817026f8ce8f4f0d2ef7ae44f947c4664efac9adec929"},
+    {file = "mypy-1.3.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:faff86aa10c1aa4a10e1a301de160f3d8fc8703b88c7e98de46b531ff1276a9a"},
+    {file = "mypy-1.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:8c5979d0deb27e0f4479bee18ea0f83732a893e81b78e62e2dda3e7e518c92ee"},
+    {file = "mypy-1.3.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:c5d2cc54175bab47011b09688b418db71403aefad07cbcd62d44010543fc143f"},
+    {file = "mypy-1.3.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:87df44954c31d86df96c8bd6e80dfcd773473e877ac6176a8e29898bfb3501cb"},
+    {file = "mypy-1.3.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:473117e310febe632ddf10e745a355714e771ffe534f06db40702775056614c4"},
+    {file = "mypy-1.3.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:74bc9b6e0e79808bf8678d7678b2ae3736ea72d56eede3820bd3849823e7f305"},
+    {file = "mypy-1.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:44797d031a41516fcf5cbfa652265bb994e53e51994c1bd649ffcd0c3a7eccbf"},
+    {file = "mypy-1.3.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ddae0f39ca146972ff6bb4399f3b2943884a774b8771ea0a8f50e971f5ea5ba8"},
+    {file = "mypy-1.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1c4c42c60a8103ead4c1c060ac3cdd3ff01e18fddce6f1016e08939647a0e703"},
+    {file = "mypy-1.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e86c2c6852f62f8f2b24cb7a613ebe8e0c7dc1402c61d36a609174f63e0ff017"},
+    {file = "mypy-1.3.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:f9dca1e257d4cc129517779226753dbefb4f2266c4eaad610fc15c6a7e14283e"},
+    {file = "mypy-1.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:95d8d31a7713510685b05fbb18d6ac287a56c8f6554d88c19e73f724a445448a"},
+    {file = "mypy-1.3.0-py3-none-any.whl", hash = "sha256:a8763e72d5d9574d45ce5881962bc8e9046bf7b375b0abf031f3e6811732a897"},
+    {file = "mypy-1.3.0.tar.gz", hash = "sha256:e1f4d16e296f5135624b34e8fb741eb0eadedca90862405b1f1fde2040b9bd11"},
+]
+
+[package.dependencies]
+mypy-extensions = ">=1.0.0"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+typing-extensions = ">=3.10"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+install-types = ["pip"]
+python2 = ["typed-ast (>=1.4.0,<2)"]
+reports = ["lxml"]
+
+[[package]]
 name = "mypy-extensions"
 version = "1.0.0"
 description = "Type system extensions for programs checked with the mypy type checker."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.5"
 files = [
@@ -853,6 +973,21 @@ developer = ["mypy (>=0.982)", "pre-commit (>=2.20)"]
 doc = ["nb2plots (>=0.6)", "numpydoc (>=1.5)", "pillow (>=9.2)", "pydata-sphinx-theme (>=0.11)", "sphinx (>=5.2)", "sphinx-gallery (>=0.11)", "texext (>=0.6.6)"]
 extra = ["lxml (>=4.6)", "pydot (>=1.4.2)", "pygraphviz (>=1.9)", "sympy (>=1.10)"]
 test = ["codecov (>=2.1)", "pytest (>=7.2)", "pytest-cov (>=4.0)"]
+
+[[package]]
+name = "nodeenv"
+version = "1.8.0"
+description = "Node.js virtual environment builder"
+category = "main"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
+files = [
+    {file = "nodeenv-1.8.0-py2.py3-none-any.whl", hash = "sha256:df865724bb3c3adc86b3876fa209771517b0cfe596beff01a92700e0e8be4cec"},
+    {file = "nodeenv-1.8.0.tar.gz", hash = "sha256:d51e0c37e64fbf47d017feac3145cdbb58836d7eee8c6f6d3b6880c5456227d2"},
+]
+
+[package.dependencies]
+setuptools = "*"
 
 [[package]]
 name = "packaging"
@@ -897,7 +1032,7 @@ files = [
 name = "platformdirs"
 version = "3.2.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -924,6 +1059,25 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "pre-commit"
+version = "3.3.1"
+description = "A framework for managing and maintaining multi-language pre-commit hooks."
+category = "main"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pre_commit-3.3.1-py2.py3-none-any.whl", hash = "sha256:218e9e3f7f7f3271ebc355a15598a4d3893ad9fc7b57fe446db75644543323b9"},
+    {file = "pre_commit-3.3.1.tar.gz", hash = "sha256:733f78c9a056cdd169baa6cd4272d51ecfda95346ef8a89bf93712706021b907"},
+]
+
+[package.dependencies]
+cfgv = ">=2.0.0"
+identify = ">=1.0.0"
+nodeenv = ">=0.11.1"
+pyyaml = ">=5.1"
+virtualenv = ">=20.10.0"
 
 [[package]]
 name = "protobuf"
@@ -1246,6 +1400,23 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "setuptools"
+version = "67.7.2"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "setuptools-67.7.2-py3-none-any.whl", hash = "sha256:23aaf86b85ca52ceb801d32703f12d77517b2556af839621c641fca11287952b"},
+    {file = "setuptools-67.7.2.tar.gz", hash = "sha256:f104fa03692a2602fa0fec6c6a9e63b6c8a968de13e17c026957dd1f53d80990"},
+]
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -1285,7 +1456,7 @@ files = [
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -1323,6 +1494,27 @@ secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "p
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
+name = "virtualenv"
+version = "20.23.0"
+description = "Virtual Python Environment builder"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "virtualenv-20.23.0-py3-none-any.whl", hash = "sha256:6abec7670e5802a528357fdc75b26b9f57d5d92f29c5462ba0fbe45feacc685e"},
+    {file = "virtualenv-20.23.0.tar.gz", hash = "sha256:a85caa554ced0c0afbd0d638e7e2d7b5f92d23478d05d17a76daeac8f279f924"},
+]
+
+[package.dependencies]
+distlib = ">=0.3.6,<1"
+filelock = ">=3.11,<4"
+platformdirs = ">=3.2,<4"
+
+[package.extras]
+docs = ["furo (>=2023.3.27)", "proselint (>=0.13)", "sphinx (>=6.1.3)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=22.12)"]
+test = ["covdefaults (>=2.3)", "coverage (>=7.2.3)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.3.1)", "pytest-env (>=0.8.1)", "pytest-freezegun (>=0.4.2)", "pytest-mock (>=3.10)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=67.7.1)", "time-machine (>=2.9)"]
+
+[[package]]
 name = "werkzeug"
 version = "2.2.3"
 description = "The comprehensive WSGI web application library."
@@ -1346,4 +1538,4 @@ postgres = ["dbt-postgres"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "caa486359bcf83d56103945287127681866bd3965a1402b9a10720d4c63bae56"
+content-hash = "af3997c87f4b59fff4abf03e427726d081c7dc723f0419879ab2e2d52197317f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,10 @@ dbt-core = "^1.5.0rc1"
 click = "^8.1.3"
 dbt-postgres = { version = "^1.5.0rc1", optional = true }
 dbt-duckdb = "^1.5.0"
+black = "^23.3.0"
+mypy = "^1.3.0"
+isort = "^5.12.0"
+pre-commit = "^3.3.1"
 
 [tool.poetry.extras]
 postgres = ['dbt-postgres']

--- a/test-projects/source-hack/dest_proj_a/models/downstream_model.sql
+++ b/test-projects/source-hack/dest_proj_a/models/downstream_model.sql
@@ -1,8 +1,8 @@
-with 
+with
 
 upstream as (
     select * from {{ ref('shared_model') }}
 )
 
-select * from upstream 
+select * from upstream
 where colleague = 'grace'

--- a/test-projects/source-hack/dest_proj_b/models/downstream_model.sql
+++ b/test-projects/source-hack/dest_proj_b/models/downstream_model.sql
@@ -1,8 +1,8 @@
-with 
+with
 
 upstream as (
     select * from {{ ref('src_proj_a', 'shared_model') }}
 )
 
-select * from upstream 
+select * from upstream
 where colleague = 'grace'

--- a/test-projects/source-hack/src_proj_b/models/_sources.yml
+++ b/test-projects/source-hack/src_proj_b/models/_sources.yml
@@ -1,4 +1,4 @@
-version: 2 
+version: 2
 
 sources:
   - name: src_proj_a

--- a/test-projects/source-hack/src_proj_b/models/downstream_model.sql
+++ b/test-projects/source-hack/src_proj_b/models/downstream_model.sql
@@ -1,8 +1,8 @@
-with 
+with
 
 upstream as (
     select * from {{ source('src_proj_a', 'shared_model') }}
 )
 
-select * from upstream 
+select * from upstream
 where colleague = 'grace'

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,33 +1,29 @@
 from dbt.contracts.results import CatalogTable
+
 shared_model_catalog_entry = CatalogTable.from_dict(
     {
-      "metadata": {
-        "type": "BASE TABLE",
-        "schema": "main",
-        "name": "shared_model",
-        "database": "database",
-        "comment": None,
-        "owner": None
-      },
-      "columns": {
-        "id": { "type": "INTEGER", "index": 1, "name": "id", "comment": None },
-        "colleague": {
-          "type": "VARCHAR",
-          "index": 2,
-          "name": "colleague",
-          "comment": None
-        }
-      },
-      "stats": {
-        "has_stats": {
-          "id": "has_stats",
-          "label": "Has Stats?",
-          "value": False,
-          "include": False,
-          "description": "Indicates whether there are statistics for this table"
-        }
-      },
-      "unique_id": "model.src_proj_a.shared_model"
+        "metadata": {
+            "type": "BASE TABLE",
+            "schema": "main",
+            "name": "shared_model",
+            "database": "database",
+            "comment": None,
+            "owner": None,
+        },
+        "columns": {
+            "id": {"type": "INTEGER", "index": 1, "name": "id", "comment": None},
+            "colleague": {"type": "VARCHAR", "index": 2, "name": "colleague", "comment": None},
+        },
+        "stats": {
+            "has_stats": {
+                "id": "has_stats",
+                "label": "Has Stats?",
+                "value": False,
+                "include": False,
+                "description": "Indicates whether there are statistics for this table",
+            }
+        },
+        "unique_id": "model.src_proj_a.shared_model",
     }
 )
 

--- a/tests/integration/test_contract_command.py
+++ b/tests/integration/test_contract_command.py
@@ -1,22 +1,26 @@
-from click.testing import CliRunner
-import yaml
 from pathlib import Path
-from dbt_meshify.main import add_contract
+
 import pytest
+import yaml
+from click.testing import CliRunner
+
+from dbt_meshify.main import add_contract
+
 from ..fixtures import (
-    model_yml_no_col,
-    expected_yml_no_col,
-    model_yml_one_col,
-    expected_yml_one_col,
-    model_yml_all_col,
     expected_yml_all_col,
+    expected_yml_no_col,
     expected_yml_no_entry,
+    expected_yml_one_col,
+    expected_yml_other_model,
+    model_yml_all_col,
+    model_yml_no_col,
+    model_yml_one_col,
     model_yml_other_model,
-    expected_yml_other_model
 )
 
 proj_path_string = "test-projects/source-hack/src_proj_a"
 proj_path = Path(proj_path_string)
+
 
 @pytest.mark.parametrize(
     "start_yml,end_yml",
@@ -25,26 +29,27 @@ proj_path = Path(proj_path_string)
         (model_yml_one_col, expected_yml_one_col),
         (model_yml_all_col, expected_yml_all_col),
         (None, expected_yml_no_entry),
-        (model_yml_other_model, expected_yml_other_model)
+        (model_yml_other_model, expected_yml_other_model),
     ],
-    ids=["1", "2", "3", "4", "5"]
+    ids=["1", "2", "3", "4", "5"],
 )
-
 def test_add_contract_to_yml(start_yml, end_yml):
-    yml_file = proj_path / 'models' / '_models.yml'
+    yml_file = proj_path / "models" / "_models.yml"
     yml_file.parent.mkdir(parents=True, exist_ok=True)
     runner = CliRunner()
     # only create file if start_yml is not None
-    # in situations where models don't have a patch path, there isn't a yml file to read from 
+    # in situations where models don't have a patch path, there isn't a yml file to read from
     if start_yml:
         yml_file.touch()
         start_yml_content = yaml.safe_load(start_yml)
-        with open(yml_file, 'w+') as f:
+        with open(yml_file, "w+") as f:
             yaml.safe_dump(start_yml_content, f, sort_keys=False)
-    result = runner.invoke(add_contract, ["--select", "shared_model", "--project-path", proj_path_string])
+    result = runner.invoke(
+        add_contract, ["--select", "shared_model", "--project-path", proj_path_string]
+    )
     assert result.exit_code == 0
     # reset the read path to the default in the logic
-    with open(yml_file, 'r') as f:
+    with open(yml_file, "r") as f:
         actual = yaml.safe_load(f)
     yml_file.unlink()
     assert actual == yaml.safe_load(end_yml)

--- a/tests/unit/test_add_contract_to_yml.py
+++ b/tests/unit/test_add_contract_to_yml.py
@@ -1,66 +1,64 @@
+import yaml
 
 from dbt_meshify.dbt_meshify import DbtMeshYmlEditor
-import yaml
+
 from ..fixtures import (
-    shared_model_catalog_entry,
-    model_yml_no_col,
-    expected_yml_no_col,
-    model_yml_one_col,
-    expected_yml_one_col,
-    model_yml_all_col,
     expected_yml_all_col,
+    expected_yml_no_col,
     expected_yml_no_entry,
+    expected_yml_one_col,
+    expected_yml_other_model,
+    model_yml_all_col,
+    model_yml_no_col,
+    model_yml_one_col,
     model_yml_other_model,
-    expected_yml_other_model
+    shared_model_catalog_entry,
 )
-
-
 
 meshify = DbtMeshYmlEditor()
 catalog_entry = shared_model_catalog_entry
-model_name = 'shared_model'
+model_name = "shared_model"
+
 
 def read_yml(yml_str):
     return yaml.safe_load(yml_str)
 
+
 class TestAddContractToYML:
-    
     def test_add_contract_to_yml_no_col(self):
         yml_dict = meshify.add_model_contract_to_yml(
-            full_yml_dict=read_yml(model_yml_no_col), 
-            model_catalog=catalog_entry, 
-            model_name=model_name
+            full_yml_dict=read_yml(model_yml_no_col),
+            model_catalog=catalog_entry,
+            model_name=model_name,
         )
         assert yml_dict == read_yml(expected_yml_no_col)
-        
+
     def test_add_contract_to_yml_one_col(self):
         yml_dict = meshify.add_model_contract_to_yml(
-            full_yml_dict=read_yml(model_yml_one_col), 
-            model_catalog=catalog_entry, 
-            model_name=model_name
+            full_yml_dict=read_yml(model_yml_one_col),
+            model_catalog=catalog_entry,
+            model_name=model_name,
         )
         assert yml_dict == read_yml(expected_yml_one_col)
 
     def test_add_contract_to_yml_all_col(self):
         yml_dict = meshify.add_model_contract_to_yml(
-            full_yml_dict=read_yml(model_yml_all_col), 
-            model_catalog=catalog_entry, 
-            model_name=model_name
+            full_yml_dict=read_yml(model_yml_all_col),
+            model_catalog=catalog_entry,
+            model_name=model_name,
         )
         assert yml_dict == read_yml(expected_yml_all_col)
 
     def test_add_contract_to_yml_no_entry(self):
         yml_dict = meshify.add_model_contract_to_yml(
-            full_yml_dict={}, 
-            model_catalog=catalog_entry, 
-            model_name=model_name
+            full_yml_dict={}, model_catalog=catalog_entry, model_name=model_name
         )
         assert yml_dict == read_yml(expected_yml_no_entry)
 
     def test_add_contract_to_yml_other_model(self):
         yml_dict = meshify.add_model_contract_to_yml(
-            full_yml_dict=read_yml(model_yml_other_model), 
-            model_catalog=catalog_entry, 
-            model_name=model_name
+            full_yml_dict=read_yml(model_yml_other_model),
+            model_catalog=catalog_entry,
+            model_name=model_name,
         )
         assert yml_dict == read_yml(expected_yml_other_model)


### PR DESCRIPTION
We should have some standard tooling for code quality! This PR adds 

Packages to project toml:
- `pre-commit`
- `black` (for code formatting)
- `isort` (cleans up imports)
- `mypy`

Files to repo
- `pre-commit-config.yaml` - defines the precommit rules! 

I am commenting out flake8 for now, since it got pretty noisy, but happy to include if we feel it's necessary. 

I applied an initial `poetry run black -S .` here to also standardize the code, so lots of edits here, but should be noncontroversial