### PR TITLE
update used gh actions ahead of node12 deprecation

### DIFF
--- a/.github/workflows/ci-tests-pytest.yml
+++ b/.github/workflows/ci-tests-pytest.yml
@@ -13,7 +13,7 @@ jobs:
       - name: checkout repo
         uses: actions/checkout@v3
       - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
       - name: Install dependencies


### PR DESCRIPTION
Please merge this update today! [node 12 support dropping tomorrow](https://github.blog/changelog/2023-05-04-github-actions-all-actions-will-run-on-node16-instead-of-node12/) and these version updates to Github Actions get ahead of that. Resolves RELENG-144