### PR TITLE
Code cleanup

### DIFF
--- a/dbt_meshify/storage/file_manager.py
+++ b/dbt_meshify/storage/file_manager.py
@@ -7,14 +7,13 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
 import yaml
-from dbt.contracts.results import CatalogTable
 
 
 class BaseFileManager(ABC):
-    def read_file(path: os.PathLike) -> None:
+    def read_file(path: Path) -> None:
         pass
 
-    def write_file(path: os.PathLike, file_contents: Any) -> None:
+    def write_file(path: Path, file_contents: Any) -> None:
         pass
 
 

--- a/dbt_meshify/storage/file_manager.py
+++ b/dbt_meshify/storage/file_manager.py
@@ -1,7 +1,6 @@
 # classes that deal specifcally with mile manipulation
 # of dbt files to be used in the meshify dbt project
 
-import os
 from abc import ABC
 from pathlib import Path
 from typing import Any, Dict, Optional, Union

--- a/dbt_meshify/storage/yaml_editors.py
+++ b/dbt_meshify/storage/yaml_editors.py
@@ -205,7 +205,7 @@ class DbtMeshModelConstructor(DbtMeshModelYmlEditor):
         return yml_path
 
     def get_model_path(self) -> Path:
-        """Returns the path to the model yml file"""
+        """Returns the path to the model file"""
         return (
             Path(self.model_node.original_file_path)
             if self.model_node.original_file_path

--- a/dbt_meshify/storage/yaml_editors.py
+++ b/dbt_meshify/storage/yaml_editors.py
@@ -9,6 +9,7 @@ from dbt.node_types import AccessType
 
 from dbt_meshify.storage.file_manager import DbtFileManager
 
+
 def process_model_yml(model_yml: str):
     """Processes the yml contents to be written back to a file"""
     model_ordered_dict = OrderedDict.fromkeys(
@@ -27,6 +28,7 @@ def process_model_yml(model_yml: str):
     # remove any keys with None values
     model_ordered_dict = {k: v for k, v in model_ordered_dict.items() if v is not None}
     return model_ordered_dict
+
 
 class DbtMeshModelYmlEditor:
     """
@@ -74,7 +76,6 @@ class DbtMeshModelYmlEditor:
 
         full_yml_dict["models"] = list(models.values())
         return full_yml_dict
-
 
     def add_model_contract_to_yml(
         self, model_name: str, model_catalog: CatalogTable, full_yml_dict: Dict[str, str]
@@ -181,8 +182,16 @@ class DbtMeshModelConstructor(DbtMeshModelYmlEditor):
 
     def get_model_yml_path(self) -> Path:
         """Returns the path to the model yml file"""
-        yml_path = Path(self.model_node.patch_path.split("://")[1]) if self.model_node.patch_path else None
-        original_file_path = Path(self.model_node.original_file_path) if self.model_node.original_file_path else None
+        yml_path = (
+            Path(self.model_node.patch_path.split("://")[1])
+            if self.model_node.patch_path
+            else None
+        )
+        original_file_path = (
+            Path(self.model_node.original_file_path)
+            if self.model_node.original_file_path
+            else None
+        )
         # if the model doesn't have a patch path, create a new yml file in the models directory
         if not yml_path:
             yml_path = original_file_path.parent / "_models.yml"
@@ -191,7 +200,11 @@ class DbtMeshModelConstructor(DbtMeshModelYmlEditor):
 
     def get_model_path(self) -> Path:
         """Returns the path to the model yml file"""
-        return Path(self.model_node.original_file_path) if self.model_node.original_file_path else None
+        return (
+            Path(self.model_node.original_file_path)
+            if self.model_node.original_file_path
+            else None
+        )
 
     def add_model_contract(self) -> None:
         """Adds a model contract to the model's yaml"""
@@ -201,7 +214,9 @@ class DbtMeshModelConstructor(DbtMeshModelYmlEditor):
         # pass empty dict if no file contents returned
         full_yml_dict = self.file_manager.read_file(yml_path) or {}
         updated_yml = self.add_model_contract_to_yml(
-            model_name=self.model_node.name, model_catalog=self.model_catalog, full_yml_dict=full_yml_dict
+            model_name=self.model_node.name,
+            model_catalog=self.model_catalog,
+            full_yml_dict=full_yml_dict,
         )
         # write the updated yml to the file
         self.file_manager.write_file(yml_path, updated_yml)
@@ -227,7 +242,9 @@ class DbtMeshModelConstructor(DbtMeshModelYmlEditor):
 
         # if we're incrementing the version, write the new version file with a copy of the code
         latest_version = self.model_node.latest_version if self.model_node.latest_version else 0
-        last_version_file_name = f"{self.model_node.name}_v{latest_version}.{self.model_node.language}"
+        last_version_file_name = (
+            f"{self.model_node.name}_v{latest_version}.{self.model_node.language}"
+        )
         next_version_file_name = (
             f"{defined_in}.{self.model_node.language}"
             if defined_in

--- a/tests/unit/test_add_contract_to_yml.py
+++ b/tests/unit/test_add_contract_to_yml.py
@@ -22,7 +22,7 @@ model_name = "shared_model"
 class TestAddContractToYML:
     def test_add_contract_to_yml_no_col(self):
         yml_dict = meshify.add_model_contract_to_yml(
-            full_yml_dict=read_yml(model_yml_no_col_no_version),
+            models_yml=read_yml(model_yml_no_col_no_version),
             model_catalog=catalog_entry,
             model_name=model_name,
         )
@@ -30,7 +30,7 @@ class TestAddContractToYML:
 
     def test_add_contract_to_yml_one_col(self):
         yml_dict = meshify.add_model_contract_to_yml(
-            full_yml_dict=read_yml(model_yml_one_col),
+            models_yml=read_yml(model_yml_one_col),
             model_catalog=catalog_entry,
             model_name=model_name,
         )
@@ -38,7 +38,7 @@ class TestAddContractToYML:
 
     def test_add_contract_to_yml_all_col(self):
         yml_dict = meshify.add_model_contract_to_yml(
-            full_yml_dict=read_yml(model_yml_all_col),
+            models_yml=read_yml(model_yml_all_col),
             model_catalog=catalog_entry,
             model_name=model_name,
         )
@@ -46,13 +46,13 @@ class TestAddContractToYML:
 
     def test_add_contract_to_yml_no_entry(self):
         yml_dict = meshify.add_model_contract_to_yml(
-            full_yml_dict={}, model_catalog=catalog_entry, model_name=model_name
+            models_yml={}, model_catalog=catalog_entry, model_name=model_name
         )
         assert yml_dict == read_yml(expected_contract_yml_no_entry)
 
     def test_add_contract_to_yml_other_model(self):
         yml_dict = meshify.add_model_contract_to_yml(
-            full_yml_dict=read_yml(model_yml_other_model),
+            models_yml=read_yml(model_yml_other_model),
             model_catalog=catalog_entry,
             model_name=model_name,
         )

--- a/tests/unit/test_add_group_and_access_to_model_yml.py
+++ b/tests/unit/test_add_group_and_access_to_model_yml.py
@@ -79,7 +79,7 @@ class TestAddGroupToModelYML:
             model_name=model_name,
             group=new_group,
             access_type=AccessType.Public,
-            full_yml_dict=read_yml(model_yml_shared_model),
+            models_yml=read_yml(model_yml_shared_model),
         )
         assert yml_dict == read_yml(expected_model_yml_shared_model)
 
@@ -88,7 +88,7 @@ class TestAddGroupToModelYML:
             model_name=model_name,
             group=new_group,
             access_type=AccessType.Public,
-            full_yml_dict=read_yml(model_yml_shared_model_with_group),
+            models_yml=read_yml(model_yml_shared_model_with_group),
         )
         assert yml_dict == read_yml(expected_model_yml_shared_model)
 
@@ -97,6 +97,6 @@ class TestAddGroupToModelYML:
             model_name=model_name,
             group=new_group,
             access_type=AccessType.Public,
-            full_yml_dict=read_yml(model_yml_multiple_models),
+            models_yml=read_yml(model_yml_multiple_models),
         )
         assert yml_dict == read_yml(expected_model_yml_multiple_models)

--- a/tests/unit/test_add_group_to_yml.py
+++ b/tests/unit/test_add_group_to_yml.py
@@ -66,18 +66,18 @@ class TestAddGroupToYML:
 
     def test_adds_groups_to_empty_file(self, new_group: Group):
         yml_dict = meshify.add_group_to_yml(
-            group=new_group, full_yml_dict=read_yml(group_yml_empty_file)
+            group=new_group, groups_yml=read_yml(group_yml_empty_file)
         )
         assert yml_dict == read_yml(expected_group_yml_no_group)
 
     def test_adds_groups_to_existing_list_of_groups(self, new_group: Group):
         yml_dict = meshify.add_group_to_yml(
-            group=new_group, full_yml_dict=read_yml(group_yml_existing_groups)
+            group=new_group, groups_yml=read_yml(group_yml_existing_groups)
         )
         assert yml_dict == read_yml(expected_group_yml_existing_groups)
 
     def test_adds_groups_updates_predefined_group(self, new_group: Group):
         yml_dict = meshify.add_group_to_yml(
-            group=new_group, full_yml_dict=read_yml(group_yml_group_predefined)
+            group=new_group, groups_yml=read_yml(group_yml_group_predefined)
         )
         assert yml_dict == read_yml(expected_group_yml_no_group)

--- a/tests/unit/test_add_version_to_yml.py
+++ b/tests/unit/test_add_version_to_yml.py
@@ -22,24 +22,24 @@ def read_yml(yml_str):
 
 class TestAddContractToYML:
     def test_add_version_to_model_yml_no_yml(self):
-        yml_dict = meshify.add_model_version_to_yml(full_yml_dict={}, model_name=model_name)
+        yml_dict = meshify.add_model_version_to_yml(models_yml={}, model_name=model_name)
         assert yml_dict == read_yml(expected_versioned_model_yml_no_yml)
 
     def test_add_version_to_model_yml_no_version(self):
         yml_dict = meshify.add_model_version_to_yml(
-            full_yml_dict=read_yml(model_yml_no_col_no_version), model_name=model_name
+            models_yml=read_yml(model_yml_no_col_no_version), model_name=model_name
         )
         assert yml_dict == read_yml(expected_versioned_model_yml_no_version)
 
     def test_add_version_to_model_yml_increment_version_no_prerelease(self):
         yml_dict = meshify.add_model_version_to_yml(
-            full_yml_dict=read_yml(model_yml_increment_version), model_name=model_name
+            models_yml=read_yml(model_yml_increment_version), model_name=model_name
         )
         assert yml_dict == read_yml(expected_versioned_model_yml_increment_version_no_prerelease)
 
     def test_add_version_to_model_yml_increment_version_with_prerelease(self):
         yml_dict = meshify.add_model_version_to_yml(
-            full_yml_dict=read_yml(model_yml_increment_version),
+            models_yml=read_yml(model_yml_increment_version),
             model_name=model_name,
             prerelease=True,
         )
@@ -47,7 +47,7 @@ class TestAddContractToYML:
 
     def test_add_version_to_model_yml_increment_version_defined_in(self):
         yml_dict = meshify.add_model_version_to_yml(
-            full_yml_dict=read_yml(model_yml_increment_version),
+            models_yml=read_yml(model_yml_increment_version),
             model_name=model_name,
             defined_in="daves_model",
         )


### PR DESCRIPTION
This PR is an attempt to simplify some existing code

1. Rework the `file_manager.py` -- these classes may still be a little heavier than we need -- effectively, I have reduced this down to a small wrapper around the `pathlib` read and write operations to handle yml in one go, rather than having two additional classes just to handle this usecase. In reality, these could just be functions, but opted to keep it within a class so we have read from and write to paths for use in the future where we're moving files between projects. 
2. Attempt to simplify the methods in our `dbt_meshify.py` file:

  - pull out common operations into helper functions outside the classes
  - rename some variables for clarity (full_yml_dict --> models_dict or groups_dict most notably) 
  - pull out a couple common filepath related operations into methods for the actual constructor

The methods in `dbt_meshify.py` are still a bit beefy -- would love to think through how we can simplify them further in this PR!