### PR TITLE
Add larger length size to prevent wrapping lines

### DIFF
--- a/dbt_meshify/storage/file_manager.py
+++ b/dbt_meshify/storage/file_manager.py
@@ -21,6 +21,7 @@ class DbtYAML(YAML):
 
 
 yaml = DbtYAML()
+yaml.width = 4096
 yaml.indent(mapping=2, sequence=4, offset=2)
 
 FileContent = Union[Dict[str, str], str]


### PR DESCRIPTION
The demo showed long YAML lines being wrapped, generating a bigger diff than needed.
This should fix it