### PR TITLE
add pypi publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,7 @@
 name: Publish
 on:
-  push:
-    tags:
-      - '*'
+  release:
+    types: [created]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,44 @@
+name: Publish
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: 3.11
+
+    - name: Install dependencies and build
+      run: |
+        python3 -m pip install --upgrade pip
+        pip install poetry
+        poetry build
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v3
+      with:
+        path: ./dist
+
+  pypi-publish:
+    needs: ['build']
+    environment: 'PypiProd'
+
+    name: upload release to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v3
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages_dir: artifact/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,9 +11,9 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.11
+        python-version: 3.9
 
     - name: Install dependencies and build
       run: |
@@ -36,7 +36,8 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
     steps:
-      - uses: actions/download-artifact@v3
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,9 @@
 name: Publish
+
 on:
   release:
     types: [created]
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Created a github workflow to publish release of package to pypi

- created a new github environment "PypiProd" (to restrict the reviewers) 
- created a new tag protection rule (to restrict who can create new tags)
- added publish.yml to the repo following [this](https://pgjones.dev/blog/trusted-plublishing-2023/) article