### PR TITLE
Feature: Update CLI for group creation to use explicit option names for group owner properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ pip install dbt-meshify
 # create a group of all models tagged with "finance"
 # leaf nodes and nodes with cross-group dependencies will be `public`
 # public nodes will also have contracts added to them
-dbt-meshify group finance --owner name Monopoly Man -s +tag:finance
+dbt-meshify group finance --owner-name "Monopoly Man" -s +tag:finance
 
 # optionally use the add-version operation to add a new version to a model
 dbt-meshify operation add-version -s fct_orders

--- a/dbt_meshify/cli.py
+++ b/dbt_meshify/cli.py
@@ -1,1 +1,66 @@
-# TODO add the logic for each meshify command to independent tasks here to make cli thinner
+import functools
+
+import click
+
+# define common parameters
+project_path = click.option(
+    "--project-path",
+    type=click.Path(exists=True),
+    default=".",
+    help="The path to the dbt project to operate on. Defaults to the current directory.",
+)
+
+exclude = click.option(
+    "--exclude",
+    "-e",
+    default=None,
+    help="The dbt selection syntax specifying the resources to exclude in the operation",
+)
+
+group_yml_path = click.option(
+    "--group-yml-path",
+    type=click.Path(exists=False),
+    help="An optional path to store the new group YAML definition.",
+)
+
+select = click.option(
+    "--select",
+    "-s",
+    default=None,
+    help="The dbt selection syntax specifying the resources to include in the operation",
+)
+
+selector = click.option(
+    "--selector",
+    default=None,
+    help="The name of the YML selector specifying the resources to include in the operation",
+)
+
+owner_name = click.option(
+    "--owner-name",
+    help="The group Owner's name.",
+)
+
+owner_email = click.option(
+    "--owner-email",
+    help="The group Owner's email address.",
+)
+
+owner_properties = click.option(
+    "--owner-properties",
+    help="Additional properties to assign to a group Owner.",
+)
+
+
+def owner(func):
+    """Add click options and argument validation for creating Owner objects."""
+
+    @functools.wraps(func)
+    def wrapper_decorator(*args, **kwargs):
+        if kwargs.get('owner_name') is None and kwargs.get('owner_email') is None:
+            raise click.UsageError(
+                "Groups require an Owner to be defined using --owner-name and/or --owner-email."
+            )
+        return func(*args, **kwargs)
+
+    return wrapper_decorator

--- a/dbt_meshify/main.py
+++ b/dbt_meshify/main.py
@@ -1,77 +1,24 @@
-import functools
 import os
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Optional
 
 import click
 import yaml
 from dbt.contracts.graph.unparsed import Owner
 
+from .cli import (
+    exclude,
+    group_yml_path,
+    owner,
+    owner_email,
+    owner_name,
+    owner_properties,
+    project_path,
+    select,
+    selector,
+)
 from .dbt_projects import DbtProject, DbtProjectHolder, DbtSubProject
 from .storage.yaml_editors import DbtMeshModelConstructor
-
-# define common parameters
-project_path = click.option(
-    "--project-path",
-    type=click.Path(exists=True),
-    default=".",
-    help="The path to the dbt project to operate on. Defaults to the current directory.",
-)
-
-exclude = click.option(
-    "--exclude",
-    "-e",
-    default=None,
-    help="The dbt selection syntax specifying the resources to exclude in the operation",
-)
-
-group_yml_path = click.option(
-    "--group-yml-path",
-    type=click.Path(exists=False),
-    help="An optional path to store the new group YAML definition.",
-)
-
-select = click.option(
-    "--select",
-    "-s",
-    default=None,
-    help="The dbt selection syntax specifying the resources to include in the operation",
-)
-
-owner_name = click.option(
-    "--owner-name",
-    help="The group Owner's name.",
-)
-
-owner_email = click.option(
-    "--owner-email",
-    help="The group Owner's email address.",
-)
-
-owner_properties = click.option(
-    "--owner-properties",
-    help="Additional properties to assign to a group Owner.",
-)
-
-selector = click.option(
-    "--selector",
-    default=None,
-    help="The name of the YML selector specifying the resources to include in the operation",
-)
-
-
-def owner(func):
-    """Add click options and argument validation for creating Owner objects."""
-
-    @functools.wraps(func)
-    def wrapper_decorator(*args, **kwargs):
-        print("Validating owner configs.")
-        # Do something before
-        value = func(*args, **kwargs)
-        # Do something after
-        return value
-
-    return wrapper_decorator
 
 
 # define cli group
@@ -244,14 +191,14 @@ def create_group(
             "The provided group-yml-path is not contained within the provided dbt project."
         )
 
-    owner: Owner = Owner(
+    group_owner: Owner = Owner(
         name=owner_name, email=owner_email, _extra=yaml.safe_load(owner_properties)
     )
 
     grouper = ResourceGrouper(project)
     grouper.add_group(
         name=name,
-        owner=owner,
+        owner=group_owner,
         select=select,
         exclude=exclude,
         selector=selector,
@@ -268,6 +215,7 @@ def create_group(
 @owner_name
 @owner_email
 @owner_properties
+@owner
 @group_yml_path
 @click.pass_context
 def group(

--- a/dbt_meshify/main.py
+++ b/dbt_meshify/main.py
@@ -169,7 +169,7 @@ def create_group(
     select: str,
     owner_name: Optional[str] = None,
     owner_email: Optional[str] = None,
-    owner_properties: str = '{}',
+    owner_properties: Optional[str] = None,
     exclude: Optional[str] = None,
     selector: Optional[str] = None,
 ):
@@ -192,7 +192,7 @@ def create_group(
         )
 
     group_owner: Owner = Owner(
-        name=owner_name, email=owner_email, _extra=yaml.safe_load(owner_properties)
+        name=owner_name, email=owner_email, _extra=yaml.safe_load(owner_properties or '{}')
     )
 
     grouper = ResourceGrouper(project)

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ Here's how that might look for the process of creating a separate `finance` subp
 # create a group of all models tagged with "finance"
 # leaf nodes and nodes with cross-group dependencies will be `public`
 # public nodes will also have contracts added to them
-dbt-meshify group finance --owner name Monopoly Man -s +tag:finance
+dbt-meshify group finance --owner-name "Monopoly Man" -s +tag:finance
 
 # optionally use the add-version operation to add a new version to a model
 dbt-meshify operation add-version -s fct_orders

--- a/tests/integration/test_create_group_command.py
+++ b/tests/integration/test_create_group_command.py
@@ -51,11 +51,9 @@ def test_create_group_command(model_yml, start_group_yml, end_group_yml):
             "shared_model",
             "--project-path",
             proj_path_string,
-            "--owner",
-            "name",
+            "--owner-name",
             "Shaina Fake",
-            "--owner",
-            "email",
+            "--owner-email",
             "fake@example.com",
         ],
     )
@@ -97,10 +95,10 @@ def test_group_group_owner_properties(name, email, end_group_yml):
     args = ["test_group", "--select", "shared_model", "--project-path", proj_path_string]
 
     if name:
-        args += ["--owner", "name", name]
+        args += ["--owner-name", name]
 
     if email:
-        args += ["--owner", "email", email]
+        args += ["--owner-email", email]
 
     runner = CliRunner()
     result = runner.invoke(create_group, args)

--- a/tests/integration/test_group_command.py
+++ b/tests/integration/test_group_command.py
@@ -36,8 +36,7 @@ def test_group_command(select, expected_public_contracted_models):
         group,
         [
             "test_group",
-            "--owner",
-            "name",
+            "--owner-name",
             "Teenage Mutant Jinja Turtles",
             "--select",
             select,


### PR DESCRIPTION
This PR updates the CLI options for group owner creation. Whereas before we required the user to provide the name of the field being updated and the value, now we have explicit properties for `--owner-name` and `--owner-email`. Additional properties are also still accepted via the `--owner-properties` option, which parses a YAML string.

Old syntax:
```console
dbt-meshify group \
  --owner name dave \
  --owner email dave@example.org \
  --owner foo bar \
  test_group_2 
```

New syntax:
```console
dbt-meshify group \
  --owner-name dave \
  --owner-email dave@example.org \
  --owner-properties '{foo: bar}' \
  test_group_2 
```

Along the way, I also added an `owner` decorator that performs validation of `--owner-*` arguments to ensure that either a name or email is always provided (as per spec), and moved click decorator definitions to `cli.py`.

Resolves: #65 