### PR TITLE
Multi option support for select

### DIFF
--- a/dbt_meshify/cli.py
+++ b/dbt_meshify/cli.py
@@ -1,6 +1,7 @@
 import functools
 
 import click
+from dbt.cli.options import MultiOption
 
 # define common parameters
 project_path = click.option(
@@ -13,6 +14,9 @@ project_path = click.option(
 exclude = click.option(
     "--exclude",
     "-e",
+    cls=MultiOption,
+    multiple=True,
+    type=tuple,
     default=None,
     help="The dbt selection syntax specifying the resources to exclude in the operation",
 )
@@ -26,14 +30,20 @@ group_yml_path = click.option(
 select = click.option(
     "--select",
     "-s",
+    cls=MultiOption,
+    multiple=True,
+    type=tuple,
     default=None,
     help="The dbt selection syntax specifying the resources to include in the operation",
 )
 
 selector = click.option(
     "--selector",
+    cls=MultiOption,
+    multiple=True,
+    type=tuple,
     default=None,
-    help="The name of the YML selector specifying the resources to include in the operation",
+    help="The name(s) of the YML selector specifying the resources to include in the operation",
 )
 
 owner_name = click.option(

--- a/tests/integration/test_create_group_command.py
+++ b/tests/integration/test_create_group_command.py
@@ -106,10 +106,6 @@ def test_create_group_command_multi_select(
     with open(other_model_file, "w") as f:
         f.write("select 1 as test")
 
-    import pdb
-
-    pdb.set_trace()
-
     runner = CliRunner()
     result = runner.invoke(
         create_group,

--- a/tests/integration/test_create_group_command.py
+++ b/tests/integration/test_create_group_command.py
@@ -134,6 +134,7 @@ def test_create_group_command_multi_select(
 
     group_yml_file.unlink()
     model_yml_file.unlink()
+    other_model_file.unlink()
 
     assert result.exit_code == 0
     assert actual_group_yml == yaml.safe_load(end_group_yml)

--- a/tests/unit/test_add_group_and_access_to_model_yml.py
+++ b/tests/unit/test_add_group_and_access_to_model_yml.py
@@ -53,6 +53,17 @@ models:
   - name: other_other_model
 """
 
+expected_model_yml_multiple_models_multi_select = """
+models:
+  - name: shared_model
+    access: public
+    group: test_group
+  - name: other_model
+    access: public
+    group: test_group
+  - name: other_other_model
+"""
+
 
 class TestAddGroupToModelYML:
     @pytest.fixture


### PR DESCRIPTION
Closes #76 

This PR uses a class from dbt to allow for `MultiOption` types for `--select`, `--exclude` and `--selector`

```
# before - yelled at you for too many options
dbt-meshify group us -s my_model your_model
```

now it works!

This code was lifted from Core directly, so I feel pretty confident that it should work!