### PR TITLE
Feature: Enable quote preservation to DbtYAML class by default

### DIFF
--- a/dbt_meshify/storage/file_manager.py
+++ b/dbt_meshify/storage/file_manager.py
@@ -1,4 +1,4 @@
-# classes that deal specifcally with mile manipulation
+# classes that deal specifically with file manipulation
 # of dbt files to be used in the meshify dbt project
 import abc
 from abc import ABC
@@ -10,19 +10,25 @@ from ruamel.yaml.compat import StringIO
 
 
 class DbtYAML(YAML):
+    """dbt-compatible YAML class."""
+
+    def __init__(self):
+        super().__init__()
+        self.preserve_quotes = True
+        self.width = 4096
+        self.indent(mapping=2, sequence=4, offset=2)
+
     def dump(self, data, stream=None, **kw):
         inefficient = False
         if stream is None:
             inefficient = True
             stream = StringIO()
-        YAML.dump(self, data, stream, **kw)
+        super().dump(data, stream, **kw)
         if inefficient:
             return stream.getvalue()
 
 
 yaml = DbtYAML()
-yaml.width = 4096
-yaml.indent(mapping=2, sequence=4, offset=2)
 
 FileContent = Union[Dict[str, str], str]
 

--- a/dbt_meshify/storage/yaml_editors.py
+++ b/dbt_meshify/storage/yaml_editors.py
@@ -100,7 +100,7 @@ class DbtMeshModelYmlEditor:
         catalog_cols = model_catalog.columns or {} if model_catalog else {}
         catalog_cols = {k.lower(): v for k, v in catalog_cols.items()}
 
-        # add the data type to the yml entry for columns that are in yml        
+        # add the data type to the yml entry for columns that are in yml
         yml_cols = [
             {**yml_col, "data_type": catalog_cols[yml_col["name"]].type.lower()}
             for yml_col in yml_cols


### PR DESCRIPTION
# Description of Changes
Update `DbtYAML` class to have quote preservation on by default. This is accomplished by setting `preserve_quotes = True` during initialization of the class.

Resolves: #66 

**Example Output**
```
 - name: customer_type
    description: Options are 'new' or 'returning', indicating if a customer has ordered more than once or has only placed their first order to date.
    tests:
      - accepted_values:
          values: ["new", "returning"]
```
