### PR TITLE
Fix: `ResourceGrouper` no longer considers `test` resources during access control inference step 

### DIFF
--- a/dbt_meshify/storage/yaml_editors.py
+++ b/dbt_meshify/storage/yaml_editors.py
@@ -100,7 +100,7 @@ class DbtMeshModelYmlEditor:
         catalog_cols = model_catalog.columns or {} if model_catalog else {}
         catalog_cols = {k.lower(): v for k, v in catalog_cols.items()}
 
-        # add the data type to the yml entry for columns that are in yml        
+        # add the data type to the yml entry for columns that are in yml
         yml_cols = [
             {**yml_col, "data_type": catalog_cols[yml_col["name"]].type.lower()}
             for yml_col in yml_cols

--- a/dbt_meshify/utilities/grouper.py
+++ b/dbt_meshify/utilities/grouper.py
@@ -55,6 +55,12 @@ class ResourceGrouper:
         }
         return resources
 
+    @classmethod
+    def clean_subgraph(cls, graph: networkx.DiGraph) -> networkx.DiGraph:
+        """Generate a subgraph that does not contain test resource types."""
+        test_nodes = set(node for node in graph.nodes if node.startswith('test'))
+        return graph.subgraph(set(graph.nodes) - test_nodes)
+
     def _generate_resource_group(
         self,
         name: str,
@@ -96,7 +102,8 @@ class ResourceGrouper:
                 f"of the {existing_group} group. Please remove {node} from its group and try again."
             )
 
-        resources = self.classify_resource_access(self.project.graph.graph, nodes)
+        cleaned_subgraph = self.clean_subgraph(self.project.graph.graph)
+        resources = self.classify_resource_access(cleaned_subgraph, nodes)
 
         return group, resources
 

--- a/tests/unit/test_resource_grouper_classification.py
+++ b/tests/unit/test_resource_grouper_classification.py
@@ -12,6 +12,19 @@ class TestResourceGrouper:
         graph.add_edges_from([("a", "b"), ("b", "c"), ("b", "d"), ("d", "1")])
         return graph
 
+    @pytest.fixture
+    def example_graph_with_tests(self):
+        graph = networkx.DiGraph()
+        graph.add_edges_from(
+            [
+                ("source.a", "model.b"),
+                ("model.b", "test.c"),
+                ("model.b", "model.d"),
+                ("model.d", "test.1"),
+            ]
+        )
+        return graph
+
     def test_resource_grouper_boundary_classification(self, example_graph):
         nodes = {"a", "b", "c", "d"}
         resources = ResourceGrouper.classify_resource_access(example_graph, nodes)
@@ -22,3 +35,7 @@ class TestResourceGrouper:
             "c": AccessType.Public,
             "d": AccessType.Public,
         }
+
+    def test_clean_graph_removes_test_nodes(self, example_graph_with_tests):
+        output_graph = ResourceGrouper.clean_subgraph(example_graph_with_tests)
+        assert set(output_graph.nodes) == {"source.a", "model.b", "model.d"}


### PR DESCRIPTION
Resolves: #86 

# Description
I've created a new class method called `clean_subgraph`, which creates a new subgraph that has all `test` nodes removed. This allows the `_generate_resource_group` to only consider access levels for non-test node connections. This will prevent nodes with only test child nodes from being marked as `private`.

A new unit test has been added to confirm functionality.