### PR TITLE
fix(cli): Create custom Command type to support custom Usage docs

### DIFF
--- a/dbt_meshify/cli.py
+++ b/dbt_meshify/cli.py
@@ -1,6 +1,7 @@
 import functools
 
 import click
+from click import Context, HelpFormatter
 from dbt.cli.options import MultiOption
 
 # define common parameters
@@ -89,3 +90,16 @@ def owner(func):
         return func(*args, **kwargs)
 
     return wrapper_decorator
+
+
+class TupleCompatibleCommand(click.Command):
+    """
+    A Click Command with a custom formatter that adds metavar options after all arguments.
+    This is valuable for commands that uses tuple-type options, since type types will eat
+    arguments.
+    """
+
+    def format_usage(self, ctx: Context, formatter: HelpFormatter) -> None:
+        pieces = self.collect_usage_pieces(ctx)
+        pieces = pieces[1:] + [pieces[0]]
+        formatter.write_usage(ctx.command_path, " ".join(pieces))

--- a/dbt_meshify/cli.py
+++ b/dbt_meshify/cli.py
@@ -95,7 +95,7 @@ def owner(func):
 class TupleCompatibleCommand(click.Command):
     """
     A Click Command with a custom formatter that adds metavar options after all arguments.
-    This is valuable for commands that uses tuple-type options, since type types will eat
+    This is valuable for commands that use tuple-type options, since type types will eat
     arguments.
     """
 

--- a/dbt_meshify/main.py
+++ b/dbt_meshify/main.py
@@ -1,3 +1,4 @@
+import functools
 import os
 import sys
 from pathlib import Path
@@ -11,6 +12,7 @@ from loguru import logger
 from dbt_meshify.storage.dbt_project_creator import DbtSubprojectCreator
 
 from .cli import (
+    TupleCompatibleCommand,
     create_path,
     exclude,
     group_yml_path,
@@ -23,7 +25,7 @@ from .cli import (
     select,
     selector,
 )
-from .dbt_projects import DbtProject, DbtProjectHolder, DbtSubProject
+from .dbt_projects import DbtProject, DbtProjectHolder
 from .storage.file_content_editors import DbtMeshConstructor
 
 log_format = "<white>{time:HH:mm:ss}</white> | <level>{level}</level> | <level>{message}</level>"
@@ -78,7 +80,10 @@ def connect(projects_dir):
     print(holder.project_map())
 
 
-@cli.command(name="split")
+@cli.command(
+    cls=TupleCompatibleCommand,
+    name="split",
+)
 @create_path
 @click.argument("project_name")
 @exclude
@@ -86,7 +91,8 @@ def connect(projects_dir):
 @read_catalog
 @select
 @selector
-def split(project_name, select, exclude, project_path, selector, create_path, read_catalog):
+@click.pass_context
+def split(ctx, project_name, select, exclude, project_path, selector, create_path, read_catalog):
     """
     Splits out a new subproject from a dbt project by adding all necessary dbt Mesh constructs to the resources based on the selected resources.
 
@@ -185,7 +191,10 @@ def add_version(select, exclude, project_path, selector, prerelease, defined_in,
                 ) from e
 
 
-@operation.command(name="create-group")
+@operation.command(
+    name="create-group",
+    cls=TupleCompatibleCommand,
+)
 @click.argument("name")
 @exclude
 @group_yml_path
@@ -248,7 +257,7 @@ def create_group(
         raise FatalMeshifyException(f"Error creating group: {name}")
 
 
-@cli.command(name="group")
+@cli.command(name="group", cls=TupleCompatibleCommand)
 @click.argument("name")
 @exclude
 @group_yml_path


### PR DESCRIPTION
Resolves: #93

# Description

This PR implements a custom Click Command type called `TupleCompatibleCommand`, which has a custom usage string implementation which places the `[OPTION]` metavar at the end of the usage string. 

**Original**
```console
dbt-meshify split [OPTIONS] PROJECT_NAME
```

**Updated**
```console
dbt-meshify split PROJECT_NAME [OPTIONS]
```

This is important from a UX perspective, since `--select` and other type-typed options will eat all subsequent strings that are not themselves options. For example, 

```console
dbt-meshify split --select foo bar
```
will yield an error, since `bar` will be interpreted as part of the selector instead of as the project name.

Now, if users follow the example, we will have the following correct usage:

```console
dbt-meshify split bar --select foo
```

