### PR TITLE
Feature: Add new exceptions for file management

### DIFF
--- a/dbt_meshify/exceptions.py
+++ b/dbt_meshify/exceptions.py
@@ -1,0 +1,22 @@
+import click
+from loguru import logger
+
+
+class FileEditorException(BaseException):
+    """Exceptions relating to errors in file generation and loading."""
+
+
+class ModelFileNotFoundError(BaseException):
+    """Unable to identify a local file that a defines Model. This indicates that the Manifest may not be valid."""
+
+
+class FatalMeshifyException(click.ClickException):
+    """An unrecoverable error in Meshify."""
+
+    def __init__(self, message):
+        super().__init__(message)
+
+    def show(self):
+        logger.error(self.message)
+        if self.__cause__ is not None:
+            logger.exception(self.__cause__)

--- a/dbt_meshify/main.py
+++ b/dbt_meshify/main.py
@@ -1,4 +1,3 @@
-import functools
 import os
 import sys
 from pathlib import Path
@@ -26,21 +25,12 @@ from .cli import (
     selector,
 )
 from .dbt_projects import DbtProject, DbtProjectHolder
+from .exceptions import FatalMeshifyException
 from .storage.file_content_editors import DbtMeshConstructor
 
 log_format = "<white>{time:HH:mm:ss}</white> | <level>{level}</level> | <level>{message}</level>"
 logger.remove()  # Remove the default sink added by Loguru
 logger.add(sys.stdout, format=log_format)
-
-
-class FatalMeshifyException(click.ClickException):
-    def __init__(self, message):
-        super().__init__(message)
-
-    def show(self):
-        logger.error(self.message)
-        if self.__cause__ is not None:
-            logger.exception(self.__cause__)
 
 
 # define cli group
@@ -234,7 +224,7 @@ def create_group(
     logger.info(f"Creating new model group in file {group_yml_path.name}")
 
     if not str(os.path.commonpath([group_yml_path, path])) == str(path):
-        raise Exception(
+        raise FatalMeshifyException(
             "The provided group-yml-path is not contained within the provided dbt project."
         )
 

--- a/dbt_meshify/storage/file_content_editors.py
+++ b/dbt_meshify/storage/file_content_editors.py
@@ -8,6 +8,7 @@ from dbt.contracts.results import CatalogTable
 from dbt.node_types import AccessType, NodeType
 from loguru import logger
 
+from dbt_meshify.exceptions import FileEditorException, ModelFileNotFoundError
 from dbt_meshify.storage.file_manager import DbtFileManager
 
 
@@ -339,7 +340,9 @@ class DbtMeshConstructor(DbtMeshFileEditor):
 
             if resource_path is None:
                 # If this happens, then the model doesn't have a model file, either, which is cause for alarm.
-                raise Exception(f"Unable to locate the file defining {self.node.name}. Aborting")
+                raise ModelFileNotFoundError(
+                    f"Unable to locate the file defining {self.node.name}. Aborting"
+                )
 
             filename = f"_{self.node.resource_type.pluralize()}.yml"
             yml_path = resource_path.parent / filename
@@ -351,9 +354,8 @@ class DbtMeshConstructor(DbtMeshFileEditor):
         """
         Returns the path to the file where the resource is defined
         for yml-only nodes (generic tests, metrics, exposures, sources)
-            this will be the path to the yml file where the definitions
+        this will be the path to the yml file where the definitions
         for all others this will be the .sql or .py file for the resource
-
         """
         return Path(self.node.original_file_path)
 
@@ -365,7 +367,9 @@ class DbtMeshConstructor(DbtMeshFileEditor):
         models_yml = self.file_manager.read_file(yml_path)
 
         if isinstance(models_yml, str):
-            raise Exception(f"Unexpected string values in dumped model data in {yml_path}.")
+            raise FileEditorException(
+                f"Unexpected string values in dumped model data in {yml_path}."
+            )
 
         updated_yml = self.add_model_contract_to_yml(
             model_name=self.node.name,
@@ -384,7 +388,9 @@ class DbtMeshConstructor(DbtMeshFileEditor):
         models_yml = self.file_manager.read_file(yml_path)
 
         if isinstance(models_yml, str):
-            raise Exception(f"Unexpected string values in dumped model data in {yml_path}.")
+            raise FileEditorException(
+                f"Unexpected string values in dumped model data in {yml_path}."
+            )
 
         updated_yml = self.add_access_to_model_yml(
             model_name=self.node.name,
@@ -433,7 +439,9 @@ class DbtMeshConstructor(DbtMeshFileEditor):
         model_path = self.get_resource_path()
 
         if model_path is None:
-            raise Exception(f"Unable to find path to model {self.node.name}. Aborting.")
+            raise ModelFileNotFoundError(
+                f"Unable to find path to model {self.node.name}. Aborting."
+            )
 
         model_folder = model_path.parent
         next_version_path = model_folder / next_version_file_name
@@ -463,7 +471,9 @@ class DbtMeshConstructor(DbtMeshFileEditor):
         model_path = self.get_resource_path()
 
         if model_path is None:
-            raise Exception(f"Unable to find path to model {self.node.name}. Aborting.")
+            raise ModelFileNotFoundError(
+                f"Unable to find path to model {self.node.name}. Aborting."
+            )
 
         # read the model file
         model_code = str(self.file_manager.read_file(model_path))

--- a/dbt_meshify/utilities/grouper.py
+++ b/dbt_meshify/utilities/grouper.py
@@ -9,6 +9,7 @@ from dbt.node_types import AccessType, NodeType
 from loguru import logger
 
 from dbt_meshify.dbt_projects import DbtProject, DbtSubProject
+from dbt_meshify.exceptions import ModelFileNotFoundError
 from dbt_meshify.storage.file_content_editors import DbtMeshFileEditor
 from dbt_meshify.storage.file_manager import DbtFileManager
 
@@ -144,7 +145,7 @@ class ResourceGrouper:
                 path = Path(model.patch_path.split("://")[1])
             else:
                 if not model.original_file_path:
-                    raise Exception("Unable to locate model file. Failing.")
+                    raise ModelFileNotFoundError("Unable to locate model file. Failing.")
 
                 path = Path(model.original_file_path).parent / '_models.yml'
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1864,6 +1864,18 @@ files = [
 ]
 
 [[package]]
+name = "types-pyyaml"
+version = "6.0.12.10"
+description = "Typing stubs for PyYAML"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-PyYAML-6.0.12.10.tar.gz", hash = "sha256:ebab3d0700b946553724ae6ca636ea932c1b0868701d4af121630e78d695fc97"},
+    {file = "types_PyYAML-6.0.12.10-py3-none-any.whl", hash = "sha256:662fa444963eff9b68120d70cda1af5a5f2aa57900003c2006d7626450eaae5f"},
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.6.3"
 description = "Backported and Experimental Type Hints for Python 3.7+"
@@ -2024,4 +2036,4 @@ postgres = ["dbt-postgres"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "f59ee99341dec150a5ff3f788aaf8c2a92b390e9aad735686f8891351fcabaea"
+content-hash = "1ff29e5c3cbaf9d81393e24f203dc3fd1446f268f70f8db5fc7f0a17de36b6b0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ mkdocs-material = "^9.1.12"
 mypy = "^1.3.0"
 pre-commit = "^3.3.1"
 pytest = "^7.3.1"
+types-pyyaml = "^6.0.12.10"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Resolves: #94 

# Description and motivation
This PR implements two new Exceptions to the code base for more descriptive error handling when required. These are:
1. `FileEditorException`: Exceptions raised by a file editor during self-checks. Currently, this applies when a YAML reader returns a `str` instead of a `Dict`.
2. `ModelFileNotFoundError`: A fatal error that occurs when a model is missing both a patch path and an original file path. This is particularly tricky, since it means that we _do not_ have an actual source for the model.

Along the way, I created an `exceptions.py` file to store these exceptions, and I moved the pre-existing `FatalMeshifyException` into this file.