### PR TITLE
Fix create path

### DIFF
--- a/dbt_meshify/cli.py
+++ b/dbt_meshify/cli.py
@@ -14,7 +14,7 @@ project_path = click.option(
 
 create_path = click.option(
     "--create-path",
-    type=click.Path(exists=True),
+    type=click.Path(exists=False),
     default=None,
     help="The path to create the new dbt project. Defaults to the name argument supplied.",
 )

--- a/dbt_meshify/main.py
+++ b/dbt_meshify/main.py
@@ -94,10 +94,11 @@ def split(ctx, project_name, select, exclude, project_path, selector, create_pat
         project_name=project_name, select=select, exclude=exclude, selector=selector
     )
     logger.info(f"Selected {len(subproject.resources)} resources: {subproject.resources}")
-    target_directory = Path(create_path) if create_path else None
-    subproject_creator = DbtSubprojectCreator(
-        subproject=subproject, target_directory=target_directory
-    )
+    if create_path:
+        create_path = Path(create_path).expanduser().resolve()
+        create_path.parent.mkdir(parents=True, exist_ok=True)
+
+    subproject_creator = DbtSubprojectCreator(subproject=subproject, target_directory=create_path)
     logger.info(f"Creating subproject {subproject.name}...")
     try:
         subproject_creator.initialize()

--- a/tests/integration/test_split_command.py
+++ b/tests/integration/test_split_command.py
@@ -123,3 +123,29 @@ class TestSplitCommand:
         child_sql = (Path(dest_project_path) / "models" / "marts" / "orders.sql").read_text()
         assert x_proj_ref in child_sql
         teardown_test_project(dest_project_path)
+
+    def test_split_one_model_create_path(self):
+        setup_test_project(src_project_path, dest_project_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            split,
+            [
+                "my_new_project",
+                "--project-path",
+                dest_project_path,
+                "--select",
+                "stg_orders",
+                "--create-path",
+                "test-projects/split/ham_sandwich",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert (
+            Path("test-projects/split/ham_sandwich") / "models" / "staging" / "stg_orders.sql"
+        ).exists()
+        x_proj_ref = "{{ ref('my_new_project', 'stg_orders') }}"
+        child_sql = (Path(dest_project_path) / "models" / "marts" / "orders.sql").read_text()
+        assert x_proj_ref in child_sql
+        teardown_test_project(dest_project_path)
+        teardown_test_project("test-projects/split/ham_sandwich")


### PR DESCRIPTION
Closes #101 

This PR makes the `create-path` CLI arg supplied to the `split` command, well, work! It now accepts any direct or relative path, allowing end users to split their projects into any directory they'd like! 

