### PR TITLE
update logic to accomodate child-only subprojects

### DIFF
--- a/dbt_meshify/linker.py
+++ b/dbt_meshify/linker.py
@@ -303,7 +303,7 @@ class Linker:
 
         # for both types, add upstream project to downstream project's dependencies.yml
         try:
-            downstream_editor.update_dependencies_yml(name=upstream_project.name)
+            downstream_editor.update_dependencies_yml(parent_project=upstream_project.name)
             logger.success(
                 f"Successfully added {dependency.upstream_project_name} to {dependency.downstream_project_name}'s dependencies.yml"
             )

--- a/dbt_meshify/main.py
+++ b/dbt_meshify/main.py
@@ -153,6 +153,10 @@ def split(ctx, project_name, select, exclude, project_path, selector, create_pat
         project_name=project_name, select=select, exclude=exclude, selector=selector
     )
     logger.info(f"Selected {len(subproject.resources)} resources: {subproject.resources}")
+    if subproject.is_project_cycle:
+        raise FatalMeshifyException(
+            f"Cannot create subproject {project_name} from {project.name} because it would create a project dependency cycle. Try adding a `+` to your selection syntax to ensure all upstream resources are properly selected"
+        )
     if create_path:
         create_path = Path(create_path).expanduser().resolve()
         create_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/integration/test_split_command.py
+++ b/tests/integration/test_split_command.py
@@ -13,29 +13,6 @@ dest_project_path = "test-projects/split/temp_proj"
 
 
 class TestSplitCommand:
-    def test_split_one_model(self):
-        setup_test_project(src_project_path, dest_project_path)
-        runner = CliRunner()
-        result = runner.invoke(
-            split,
-            [
-                "my_new_project",
-                "--project-path",
-                dest_project_path,
-                "--select",
-                "stg_orders",
-            ],
-        )
-
-        assert result.exit_code == 0
-        assert (
-            Path(dest_project_path) / "my_new_project" / "models" / "staging" / "stg_orders.sql"
-        ).exists()
-        x_proj_ref = "{{ ref('my_new_project', 'stg_orders') }}"
-        child_sql = (Path(dest_project_path) / "models" / "marts" / "orders.sql").read_text()
-        assert x_proj_ref in child_sql
-        teardown_test_project(dest_project_path)
-
     def test_split_one_model_one_source(self):
         setup_test_project(src_project_path, dest_project_path)
         runner = CliRunner()
@@ -134,7 +111,7 @@ class TestSplitCommand:
                 "--project-path",
                 dest_project_path,
                 "--select",
-                "stg_orders",
+                "+stg_orders",
                 "--create-path",
                 "test-projects/split/ham_sandwich",
             ],
@@ -149,3 +126,57 @@ class TestSplitCommand:
         assert x_proj_ref in child_sql
         teardown_test_project(dest_project_path)
         teardown_test_project("test-projects/split/ham_sandwich")
+
+    def test_split_child_project(self):
+        """
+        Test that splitting out a project downstream of the base project splits as expected
+        """
+        setup_test_project(src_project_path, dest_project_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            split,
+            [
+                "my_new_project",
+                "--project-path",
+                dest_project_path,
+                "--select",
+                "+stg_orders+",
+            ],
+        )
+
+        assert result.exit_code == 0
+        # selected model is moved to subdirectory
+        assert (
+            Path(dest_project_path) / "my_new_project" / "models" / "staging" / "stg_orders.sql"
+        ).exists()
+        x_proj_ref = "{{ ref('split_proj', 'stg_order_items') }}"
+        child_sql = (
+            Path(dest_project_path) / "my_new_project" / "models" / "marts" / "orders.sql"
+        ).read_text()
+        # split model is updated to reference the parent project
+        assert x_proj_ref in child_sql
+        # dependencies.yml is moved to subdirectory, not the parent project
+        assert (Path(dest_project_path) / "my_new_project" / "dependencies.yml").exists()
+        assert not (Path(dest_project_path) / "dependencies.yml").exists()
+        teardown_test_project(dest_project_path)
+
+    def test_split_project_cycle(self):
+        """
+        Test that splitting out a project downstream of the base project splits as expected
+        """
+        setup_test_project(src_project_path, dest_project_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            split,
+            [
+                "my_new_project",
+                "--project-path",
+                dest_project_path,
+                "--select",
+                "orders",
+            ],
+        )
+
+        assert result.exit_code == 1
+
+        teardown_test_project(dest_project_path)


### PR DESCRIPTION
This turned into a bigger one than anticipated!

## Problem
The current `split` command checks for children of the selected resources, and updates those refs to select from the newly generated project. What it does _not_ do is update the _parents_ of the selected nodes, and apply the same checks (contract, make public those models, and update the refs within the selected models to refer to the "parent" project)


## Solution
When a subproject is created, list out the nodes that are cross project parents and children of the selected resources:

1. If there are both cross project parents and children of the selected nodes **_stop execution_** -- per our best practices, we should not allow for project cycles like this:
![image](https://github.com/dbt-labs/dbt-meshify/assets/73915542/fded143d-ef3a-44f9-a2ea-4c32e16807cf)

`a --> b --> a` is no good!

2. proceed as normal for boundary nodes - cross project children of selected resources get their sql updated to refer to the newly created project
3. for any selected resource that depends on one of the cross project parents, update its SQL to refer to the models in the parent project
4. for the non-selected resources that are the parents of the selected resources, add contracts and access to allow the new project to select from the across projects. 





