### PR TITLE
Fix: Update `update_dependencies_yml` to return a `ResourceChange` and not a `FileChange`

### DIFF
--- a/dbt_meshify/storage/dbt_project_editors.py
+++ b/dbt_meshify/storage/dbt_project_editors.py
@@ -167,7 +167,6 @@ class DbtSubprojectCreator:
                 change_set.add(self.move_resource(resource))
                 change_set.extend(self.move_resource_yml_entry(resource))
 
-
                 if isinstance(resource, (ModelNode, GenericTestNode, SnapshotNode)) and any(
                     node
                     for node in resource.depends_on.nodes

--- a/tests/integration/test_connect_command.py
+++ b/tests/integration/test_connect_command.py
@@ -136,3 +136,28 @@ class TestConnectCommand:
         teardown_test_project(subdir_package_consumer_project)
         teardown_test_project(subdir_source_consumer_project)
         teardown_test_project(subdir_producer_project.parent)
+
+    def test_connect_source_hack_existing_dependency(self, producer_project):
+        """Test that connecting projects via source-hacked dependencies will not add duplicate dependency listings."""
+
+        # Add a previous project to confirm that we're not overwriting or duplicating anything.
+        dependency_path = Path(copy_source_consumer_project_path) / "dependencies.yml"
+
+        dependency_path.write_text("projects:\n - name: src_proj_b")
+
+        runner = CliRunner()
+        runner.invoke(
+            cli,
+            [
+                "connect",
+                "--project-paths",
+                copy_producer_project_path,
+                copy_source_consumer_project_path,
+            ],
+        )
+
+        # assert that the dependencies.yml was preserved existing project dependency
+        assert "src_proj_b" in dependency_path.read_text()
+
+        # assert that the dependencies.yml was created with a pointer to the upstream project
+        assert "src_proj_a" in dependency_path.read_text()


### PR DESCRIPTION
# Description and motivations
In issue #127, @graciegoheen found that a `dependencies.yml` file could be created during connection operations with duplicate projects listed. I was able to determine that this was happening due to the `update_dependencies_yml` file performing a bunch of file-level operations and thereby bypassing all of our handy serialization code. Instead, we can avoid this by using the `Project` `EntityType`, which allows us to instead return a `ResourceChange` with just the new project listing. No more will this method need to read the file's current state and attempt to update it manually. A _much_ better approach IMHO. Along the way, I added an integration test to keep an eye on this in the future.