### PR TITLE
fix patch paths for macros

### DIFF
--- a/dbt_meshify/dbt_projects.py
+++ b/dbt_meshify/dbt_projects.py
@@ -231,14 +231,18 @@ class PathedProject:
 
     def resolve_patch_path(self, node: Union[Resource, CompiledNode]) -> Path:
         """Get a YML patch path for a node"""
-        if isinstance(node, ParsedNode):
+        if isinstance(node, (ParsedNode, Macro)):
             if not node.patch_path and not node.original_file_path:
                 raise FileNotFoundError(
                     f"Unable to identify patch path for resource {node.unique_id}"
                 )
 
             if not node.patch_path:
-                return self.path / Path(node.original_file_path).parent / "_models.yml"
+                return (
+                    self.path
+                    / Path(node.original_file_path).parent
+                    / f"_{node.resource_type.pluralize()}.yml"
+                )
 
             return self.path / Path(node.patch_path.split(":")[-1][2:])
 

--- a/dbt_meshify/storage/dbt_project_editors.py
+++ b/dbt_meshify/storage/dbt_project_editors.py
@@ -136,7 +136,6 @@ class DbtSubprojectCreator:
 
         for unique_id in subproject.resources | subproject.custom_macros | subproject.groups:
             resource = subproject.get_manifest_node(unique_id)
-
             if not resource:
                 raise KeyError(f"Resource {unique_id} not found in manifest")
             if resource.resource_type in ["model", "test", "snapshot", "seed"]:
@@ -257,7 +256,7 @@ class DbtSubprojectCreator:
         )
         return ResourceChange(
             operation=Operation.Add,
-            entity_type=EntityType[resource.resource_type.value],
+            entity_type=EntityType(resource.resource_type.value),
             identifier=resource.name,
             path=new_yml_path,
             data=resource_entry,

--- a/test-projects/split/split_proj/macros/_macros.yml
+++ b/test-projects/split/split_proj/macros/_macros.yml
@@ -1,0 +1,3 @@
+macros:
+  - name: cents_to_dollars
+    description: Converts cents to dollars


### PR DESCRIPTION
Closes #134 

This should properly resolve the patch path for documented macros! Otherwise, the `split.initialize()` function will fail when trying to `copy_resource_yml`