### PR TITLE
clean subgraph before identifying boundary in split operation

### DIFF
--- a/dbt_meshify/storage/dbt_project_editors.py
+++ b/dbt_meshify/storage/dbt_project_editors.py
@@ -73,9 +73,8 @@ class DbtSubprojectCreator:
         """
         nodes = set(filter(lambda x: not x.startswith("source"), self.subproject.resources))  # type: ignore
         parent_project_name = self.subproject.parent_project.name  # type: ignore
-        interface = ResourceGrouper.identify_interface(
-            graph=self.subproject.graph.graph, selected_bunch=nodes
-        )
+        cleaned_graph = ResourceGrouper.clean_subgraph(self.subproject.graph.graph)
+        interface = ResourceGrouper.identify_interface(graph=cleaned_graph, selected_bunch=nodes)
         boundary_models = set(
             filter(
                 lambda x: (x.startswith("model") and x.split(".")[1] == parent_project_name),

--- a/test-projects/split/split_proj/models/marts/__models.yml
+++ b/test-projects/split/split_proj/models/marts/__models.yml
@@ -80,3 +80,13 @@ models:
         description: A boolean indicating if this order included any food items.
       - name: is_drink_order
         description: A boolean indicating if this order included any drink items.
+
+
+  - name: leaf_node
+    description: A leaf node model that is not referenced by any other model.
+    columns:
+      - name: order_id
+        description: The unique key of the leaf node.
+        tests:
+          - not_null
+          - unique

--- a/test-projects/split/split_proj/models/marts/leaf_node.sql
+++ b/test-projects/split/split_proj/models/marts/leaf_node.sql
@@ -1,0 +1,1 @@
+select * from {{ ref('stg_orders') }}

--- a/tests/integration/test_split_command.py
+++ b/tests/integration/test_split_command.py
@@ -214,3 +214,33 @@ class TestSplitCommand:
         assert result.exit_code == 1
 
         teardown_test_project(dest_project_path)
+
+    def test_split_public_leaf_nodes(self, project):
+        """
+        asserts that the split command will split out a model that is a leaf node mark it as public
+        """
+        setup_test_project(src_project_path, dest_project_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "split",
+                "my_new_project",
+                "--project-path",
+                dest_project_path,
+                "--select",
+                "+leaf_node",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert (
+            Path(dest_project_path) / "my_new_project" / "models" / "marts" / "leaf_node.sql"
+        ).exists()
+        # this is lazy, but this should be the only model in that yml file
+        assert (
+            "access: public"
+            in (
+                Path(dest_project_path) / "my_new_project" / "models" / "marts" / "__models.yml"
+            ).read_text()
+        )


### PR DESCRIPTION
This PR adds a line to clean the subproject's graph of test nodes before identifying the boundary nodes. 

This operation is called during the creation of a group, but not splitting a project, resulting in divergent behavior. 

to test this, I added a tested leaf node to the project, and added a test case that splits that node out and makes sure it's public. I did a lazy version of checking the yml -- @nicholasyager should that be a named list?