### PR TITLE
build and leverage child and parent maps to properly evaluate cross project dependencies

### DIFF
--- a/dbt_meshify/dbt_projects.py
+++ b/dbt_meshify/dbt_projects.py
@@ -85,9 +85,6 @@ class BaseDbtProject:
         for resource in self.resources:
             if resource.startswith("test"):
                 continue
-            import ipdb
-
-            ipdb.set_trace()
             all_parents.update(self.parent_map.get(resource, []))
         return all_parents - self.resources
 

--- a/dbt_meshify/dbt_projects.py
+++ b/dbt_meshify/dbt_projects.py
@@ -60,8 +60,6 @@ class BaseDbtProject:
         }
 
         self._graph = None
-        self.child_map: Dict[str, Set[str]] = {}
-        self.parent_map: Dict[str, Set[str]] = {}
         self._build_parent_and_child_maps()
 
         self._changes: Dict[str, str] = {}
@@ -91,8 +89,6 @@ class BaseDbtProject:
         return all_parents - self.resources
 
     def _build_parent_and_child_maps(self) -> None:
-        if hasattr(self.manifest, "child_map") and hasattr(self, "parent_map"):
-            return
         self.manifest.build_parent_and_child_maps()
         self.child_map = self.manifest.child_map
         self.parent_map = self.manifest.parent_map

--- a/dbt_meshify/dbt_projects.py
+++ b/dbt_meshify/dbt_projects.py
@@ -77,7 +77,7 @@ class BaseDbtProject:
         for resource in self.resources:
             if resource.startswith("test"):
                 continue
-            all_children.update(self.child_map.get(resource, {}))
+            all_children.update(self.child_map.get(resource, []))
         return all_children - self.resources
 
     def _get_xproj_parents_of_selected_nodes(self) -> Set[str]:
@@ -85,7 +85,10 @@ class BaseDbtProject:
         for resource in self.resources:
             if resource.startswith("test"):
                 continue
-            all_parents.update(self.parent_map.get(resource, {}))
+            import ipdb
+
+            ipdb.set_trace()
+            all_parents.update(self.parent_map.get(resource, []))
         return all_parents - self.resources
 
     def _build_parent_and_child_maps(self) -> None:

--- a/dbt_meshify/utilities/references.py
+++ b/dbt_meshify/utilities/references.py
@@ -133,7 +133,6 @@ class ReferenceUpdater:
 
         change_set = ChangeSet()
 
-        # import ipdb; ipdb.set_trace()
         for model in self.project.child_map[resource.unique_id]:
             if model in self.project.resources:
                 continue

--- a/dbt_meshify/utilities/references.py
+++ b/dbt_meshify/utilities/references.py
@@ -133,7 +133,10 @@ class ReferenceUpdater:
 
         change_set = ChangeSet()
 
-        for model in self.project.xproj_children_of_resources:
+        # import ipdb; ipdb.set_trace()
+        for model in self.project.child_map[resource.unique_id]:
+            if model in self.project.resources:
+                continue
             model_node = self.project.get_manifest_node(model)
             if not model_node:
                 raise KeyError(f"Resource {model} not found in manifest")


### PR DESCRIPTION
resolves #143 

I will also split an additional issue out to track the question of "what happens if a downstream node has two cross-project parents?

this PR adds:
- logic to build the `child_map` and `parent_map` objects into dbt projects
- uses those maps to simplify and clarify the logic that detects cross project parents and children
- updates the logic in `update_child_refs` to _only evaluate children of the model called in the split operation_ (the original motivation of this PR!)

