### PR TITLE
fix: Connecting disjoint projects does not raise NoneType error

### DIFF
--- a/dbt_meshify/main.py
+++ b/dbt_meshify/main.py
@@ -110,7 +110,7 @@ def operation():
 @read_catalog
 def connect(
     project_paths: tuple, projects_dir: Path, exclude_projects: List[str], read_catalog: bool
-):
+) -> List[ChangeSet]:
     """
     Connects multiple dbt projects together by adding all necessary dbt Mesh constructs
     """
@@ -164,8 +164,8 @@ def connect(
         )
         all_dependencies.update(dependencies)
     if len(all_dependencies) == 0:
-        logger.info("No dependencies found between any of the projects")
-        return
+        logger.warning("No dependencies found between any of the projects")
+        return []
 
     noun = "dependency" if len(all_dependencies) == 1 else "dependencies"
     logger.info(f"Found {len(all_dependencies)} unique {noun} between all projects.")


### PR DESCRIPTION
# Description and motivation

There was a typing issue in the `connect` cli command, where returning early would return None, which would trip up the change_set_procesor. I've added type hints to the connect function to prevent this error in the future, and set the early return to return an empty list.

Along the way, I updated the log record created when there are no project dependencies to be a warning instead of info. Ideally, this will make it more clear when there's nothing to be done.

Resolves #141 