### PR TITLE
Fix: Update default access used in group creation to `protected`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ maintained with :heart: by dbt practitioners for dbt practitioners
 
 These dbt-core features include:
 
-1. __[Groups](https://docs.getdbt.com/docs/build/groups)__ - group your models into logical sets.
-2. __[Contracts](https://docs.getdbt.com/docs/collaborate/govern/model-contracts)__ - add model contracts to your models to ensure consistent data shape.
-3. __[Access](https://docs.getdbt.com/docs/collaborate/govern/model-access)__ - control the `access` level of models within groups
-4. __[Versions](https://docs.getdbt.com/docs/collaborate/govern/model-versions)__ - create and increment versions of particular models.
+1. **[Groups](https://docs.getdbt.com/docs/build/groups)** - group your models into logical sets.
+2. **[Contracts](https://docs.getdbt.com/docs/collaborate/govern/model-contracts)** - add model contracts to your models to ensure consistent data shape.
+3. **[Access](https://docs.getdbt.com/docs/collaborate/govern/model-access)** - control the `access` level of models within groups
+4. **[Versions](https://docs.getdbt.com/docs/collaborate/govern/model-versions)** - create and increment versions of particular models.
 
 ## Installation
 
@@ -27,8 +27,8 @@ pip install dbt-meshify
 
 ```bash
 # create a group of all models tagged with "finance"
-# leaf nodes and nodes with cross-group dependencies will be `public`
-# public nodes will also have contracts added to them
+# leaf nodes and nodes with cross-group dependencies will be `protected`
+# public and protected nodes will also have contracts added to them
 dbt-meshify group finance --owner-name "Monopoly Man" -s +tag:finance
 
 # optionally use the add-version operation to add a new version to a model

--- a/dbt_meshify/main.py
+++ b/dbt_meshify/main.py
@@ -464,7 +464,7 @@ def group(
                 for change in group_changes[0]
                 if isinstance(change, ResourceChange)
                 and change.entity_type == EntityType.Model
-                and change.data["access"] == "public"
+                and change.data["access"] != "private"
             ]
         ),
         project_path=project_path,

--- a/dbt_meshify/main.py
+++ b/dbt_meshify/main.py
@@ -444,17 +444,17 @@ def group(
 ) -> List[ChangeSet]:
     """
     Creates a new dbt group based on the selection syntax
-    Detects the edges of the group, makes their access public, and adds contracts to them
+    Detects the edges of the group, makes their access protected, and adds contracts to them
     """
 
     group_changes: List[ChangeSet] = ctx.forward(create_group)
 
     # Here's where things get a little weird. We only want to add contracts to projects
-    # that have a public access configuration on the boundary of our group. But, we don't
+    # that have a non-private access configuration on the boundary of our group. But, we don't
     # actually want to update our manifest yet. This puts us between a rock and a hard place.
     # to work around this, we can "trust" that create_group will always return a change for
-    # each public model, and rewrite our selection criteria to only select the models that
-    # will be having a public access config.
+    # each accessible model, and rewrite our selection criteria to only select the models that
+    # will be having a non-private access config.
 
     contract_changes = ctx.invoke(  # noqa: F841
         add_contract,

--- a/dbt_meshify/utilities/grouper.py
+++ b/dbt_meshify/utilities/grouper.py
@@ -43,12 +43,12 @@ class ResourceGrouper:
         Identify what access types each node should have. We can make some simplifying assumptions about
         recommended access for a group.
 
-        For example, interfaces (nodes on the boundary of a subgraph or leaf nodes) should be public,
+        For example, interfaces (nodes on the boundary of a subgraph or leaf nodes) should be protected,
         whereas nodes that are not a referenced are safe for a private access level.
         """
         boundary_nodes = cls.identify_interface(graph, nodes)
         resources = {
-            node: AccessType.Public if node in boundary_nodes else AccessType.Private
+            node: AccessType.Protected if node in boundary_nodes else AccessType.Private
             for node in nodes
         }
         logger.info(f"Identified resource access types based on the graph: {resources}")

--- a/tests/integration/test_group_command.py
+++ b/tests/integration/test_group_command.py
@@ -50,7 +50,7 @@ def test_group_command(select, expected_public_contracted_models):
     public_contracted_models = [
         model.name
         for _, model in project.models.items()
-        if model.access == "public" and model.config.contract.enforced
+        if model.access == "protected" and model.config.contract.enforced
     ]
     assert public_contracted_models == expected_public_contracted_models
     teardown_test_project(dest_path_string)

--- a/tests/unit/test_add_group_and_access_to_model_yml.py
+++ b/tests/unit/test_add_group_and_access_to_model_yml.py
@@ -58,10 +58,10 @@ models:
 expected_model_yml_multiple_models_multi_select = """
 models:
   - name: shared_model
-    access: public
+    access: protected
     group: test_group
   - name: other_model
-    access: public
+    access: protected
     group: test_group
   - name: other_other_model
 """

--- a/tests/unit/test_resource_grouper_classification.py
+++ b/tests/unit/test_resource_grouper_classification.py
@@ -32,8 +32,8 @@ class TestResourceGrouper:
         assert resources == {
             "a": AccessType.Private,
             "b": AccessType.Private,
-            "c": AccessType.Public,
-            "d": AccessType.Public,
+            "c": AccessType.Protected,
+            "d": AccessType.Protected,
         }
 
     def test_clean_graph_removes_test_nodes(self, example_graph_with_tests):


### PR DESCRIPTION
# Description and motivation
In issue #119, we discussed that it doesn't make sense for the default access level granted during grouping to be `public`, since that would provide unexpected cross-project access. This PR updates the default access level granted to instead be `protected`. This will ensure that all models in the project can access the model, without granting cross-project access.

Resolves: #119 