### PR TITLE
Fix: `require-dbt-versions` no longer serialized as a list of characters

### DIFF
--- a/dbt_meshify/storage/dbt_project_editors.py
+++ b/dbt_meshify/storage/dbt_project_editors.py
@@ -96,9 +96,13 @@ class DbtSubprojectCreator:
         contents.pop("query-comment")
         contents = filter_empty_dict_items(contents)
 
-        # Serialize the `require-dbt-version` field into a string
+        # Serialize the `require-dbt-version` field into a string. This happens because dbt is expecting a list of
+        # strings, but also accepts a singular string value, too. We can handle the latter case by checking the length
+        # of each item in the list. If they're all one character long, then we're really working with a single version
+        # string.
         if "require-dbt-version" in contents:
-            contents["require-dbt-version"] = "".join(contents["require-dbt-version"])
+            if max([len(version) for version in contents["require-dbt-version"]]) == 1:
+                contents["require-dbt-version"] = "".join(contents["require-dbt-version"])
 
         return FileChange(
             operation=Operation.Add,

--- a/dbt_meshify/storage/dbt_project_editors.py
+++ b/dbt_meshify/storage/dbt_project_editors.py
@@ -95,7 +95,11 @@ class DbtSubprojectCreator:
         # this one appears in the project yml, but i don't think it should be written
         contents.pop("query-comment")
         contents = filter_empty_dict_items(contents)
-        # project_file_path = self.target_directory / Path("dbt_project.yml")
+
+        # Serialize the `require-dbt-version` field into a string
+        if "require-dbt-version" in contents:
+            contents["require-dbt-version"] = "".join(contents["require-dbt-version"])
+
         return FileChange(
             operation=Operation.Add,
             entity_type=EntityType.Code,

--- a/test-projects/split/split_proj/dbt_project.yml
+++ b/test-projects/split/split_proj/dbt_project.yml
@@ -1,13 +1,12 @@
-
 # Name your project! Project names should contain only lowercase characters
 # and underscores. A good package name should reflect your organization's
 # name or the intended use of these models
-name: 'split_proj'
-version: '1.0.0'
+name: "split_proj"
+version: "1.0.0"
 config-version: 2
 
 # This setting configures which "profile" dbt uses for this project.
-profile: 'split_proj'
+profile: "split_proj"
 
 # These configurations specify where dbt should look for different types of files.
 # The `model-paths` config, for example, states that models in this project can be
@@ -20,10 +19,11 @@ seed-paths: ["seeds", "jaffle_data"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 
-clean-targets:         # directories to be removed by `dbt clean`
+clean-targets: # directories to be removed by `dbt clean`
   - "target"
   - "dbt_packages"
 
+require-dbt-version: [">=1.6.0", "<1.7.0"]
 
 vars:
   truncate_timespan_to: "{{ current_timestamp() }}"
@@ -43,7 +43,6 @@ models:
 
 seeds:
   +schema: jaffle_raw
-
 # the below config for seeds is only relevant when seeding the project for the fist time with the raw jaffle data
 # pont the seed path to the jaffle data directory and make sure this is uncommented
 


### PR DESCRIPTION
# Description and motivations
The internal `Project` representation of the `require-dbt-versions` field within `dbt-core` is a list of strings, where each part of the version is an element in the list. When serialized in `write_project_file`, the resulting YAML is _also_ a list of strings. This PR adds some formatting to the `write_project_file` function to join the elements of the list into one complete string.

Resolves: #138 

# Example

## Input
```yml
# Name your project! Project names should contain only lowercase characters
# and underscores. A good package name should reflect your organization's
# name or the intended use of these models
name: "split_proj"
version: "1.0.0"
config-version: 2

# This setting configures which "profile" dbt uses for this project.
profile: "split_proj"

# These configurations specify where dbt should look for different types of files.
# The `model-paths` config, for example, states that models in this project can be
# found in the "models/" directory. You probably won't need to change these!
model-paths: ["models"]
analysis-paths: ["analyses"]
test-paths: ["tests"]
seed-paths: ["seeds", "jaffle_data"]
# seed-paths: ["jaffle_data"]
macro-paths: ["macros"]
snapshot-paths: ["snapshots"]

require-dbt-version: ">=1.6.0"

clean-targets: # directories to be removed by `dbt clean`
  - "target"
  - "dbt_packages"

vars:
  truncate_timespan_to: "{{ current_timestamp() }}"

# Configuring models
# Full documentation: https://docs.getdbt.com/docs/configuring-models

# In this example config, we tell dbt to build all models in the example/
# directory as views. These settings can be overridden in the individual model
# files using the `{{ config(...) }}` macro.
models:
  split_proj:
    # Config indicated by + and applies to all files under models/example/
    +on_schema_change: append_new_columns
    example:
      +materialized: view

seeds:
  +schema: jaffle_raw
# the below config for seeds is only relevant when seeding the project for the fist time with the raw jaffle data
# pont the seed path to the jaffle data directory and make sure this is uncommented

# seeds:
#   split_proj:
#     +schema: jaffle_raw

```

## Command

```console
dbt-meshify --debug split orders --select +stg_orders+           
```

## Output
```yml
name: orders
config-version: 2
model-paths:
  - models
macro-paths:
  - macros
seed-paths:
  - seeds
  - jaffle_data
test-paths:
  - tests
analysis-paths:
  - analyses
snapshot-paths:
  - snapshots
clean-targets:
  - target
  - dbt_packages
profile: split_proj
require-dbt-version: '>=1.6.0'
models:
  orders:
    +on_schema_change: append_new_columns
    example:
      +materialized: view
seeds:
  +schema: jaffle_raw
vars:
  truncate_timespan_to: '{{ current_timestamp() }}'

```