### PR TITLE
filter out package paths, local and global

### DIFF
--- a/dbt_meshify/main.py
+++ b/dbt_meshify/main.py
@@ -137,7 +137,9 @@ def connect(
 
     if projects_dir:
         dbt_project_paths = [
-            path.parent.resolve() for path in Path(projects_dir).glob("**/dbt_project.yml")
+            path.parent.resolve()
+            for path in Path(projects_dir).glob("**/dbt_project.yml")
+            if ("dbt_packages" not in path.parts and "site-packages" not in path.parts)
         ]
         all_dbt_projects = [
             DbtProject.from_directory(project_path, read_catalog)

--- a/test-projects/source-hack/src_proj_a/packages.yml
+++ b/test-projects/source-hack/src_proj_a/packages.yml
@@ -1,0 +1,3 @@
+packages:
+  - package: dbt-labs/dbt_utils
+    version: 1.1.1

--- a/tests/integration/test_dependency_detection.py
+++ b/tests/integration/test_dependency_detection.py
@@ -17,9 +17,14 @@ class TestLinkerSourceDependencies:
     @pytest.fixture
     def src_proj_a(self) -> DbtProject:
         """Load the `src_proj_a` project."""
-        return DbtProject.from_directory(
-            Path("test-projects/source-hack/src_proj_a/").resolve(), read_catalog=False
-        )
+
+        path = Path("test-projects/source-hack/src_proj_a/").resolve()
+
+        # Run `dbt deps` for this project so upstream projects are loaded.
+        dbt = Dbt()
+        dbt.invoke(path, ["deps"])
+
+        return DbtProject.from_directory(path, read_catalog=False)
 
     @pytest.fixture
     def src_proj_b(self) -> DbtProject:


### PR DESCRIPTION
If you are using the `--projects-dir` arg, and your projects have packages installed, the `glob` method we use will pick up those project_paths as well. SImilarly, global packages in your virtual environment, if your venv is in the `--projects-dir` will get picked up here too. 

This filters out projects that are in a directory containing `dbt_packages`  or `site-packages`