### PR TITLE
ensure path is a file not a directory

### DIFF
--- a/dbt_meshify/main.py
+++ b/dbt_meshify/main.py
@@ -139,7 +139,11 @@ def connect(
         dbt_project_paths = [
             path.parent.resolve()
             for path in Path(projects_dir).glob("**/dbt_project.yml")
-            if ("dbt_packages" not in path.parts and "site-packages" not in path.parts)
+            if (
+                "dbt_packages" not in path.parts
+                and "site-packages" not in path.parts
+                and path.is_file()
+            )
         ]
         all_dbt_projects = [
             DbtProject.from_directory(project_path, read_catalog)

--- a/test-projects/source-hack/src_proj_a/dbt_project.yml
+++ b/test-projects/source-hack/src_proj_a/dbt_project.yml
@@ -24,6 +24,7 @@ clean-targets:         # directories to be removed by `dbt clean`
   - "target"
   - "dbt_packages"
 
+on-run-end: "select true as col"
 
 # Configuring models
 # Full documentation: https://docs.getdbt.com/docs/configuring-models


### PR DESCRIPTION
closes #161 

When a project has hooks defined in `dbt_project.yml`, the target directory contains a subdirectory called `dbt_project.yml` that contains the compiled sql. Our current logic for the `connect` command will attempt to compile a project at that directory instead of ignoring it. 

This PR adds a check to ensure we only look at files, not directories. 