### PR TITLE
Fix: Raise a DbtMeshifyError if a project path is provided that does not contain a `dbt_project.yml` file

### DIFF
--- a/dbt_meshify/dbt_projects.py
+++ b/dbt_meshify/dbt_projects.py
@@ -25,6 +25,7 @@ from dbt.node_types import NodeType
 from loguru import logger
 
 from dbt_meshify.dbt import Dbt
+from dbt_meshify.exceptions import FatalMeshifyException
 
 
 class BaseDbtProject:
@@ -256,7 +257,15 @@ class DbtProject(BaseDbtProject, PathedProject):
     @staticmethod
     def _load_project(path) -> Project:
         """Load a dbt Project configuration"""
-        project_dict = yaml.load(open(os.path.join(path, "dbt_project.yml")), Loader=yaml.Loader)
+        try:
+            project_dict = yaml.load(
+                open(os.path.join(path, "dbt_project.yml")), Loader=yaml.Loader
+            )
+        except FileNotFoundError:
+            raise FatalMeshifyException(
+                f"The provided directory ({path}) does not contain a dbt project."
+            )
+
         return Project.from_dict(project_dict)
 
     @classmethod

--- a/dbt_meshify/dbt_projects.py
+++ b/dbt_meshify/dbt_projects.py
@@ -16,7 +16,6 @@ from dbt.contracts.graph.nodes import (
     ModelNode,
     ParsedNode,
     Resource,
-    SnapshotNode,
     SourceDefinition,
 )
 from dbt.contracts.project import Project

--- a/tests/integration/test_connect_command.py
+++ b/tests/integration/test_connect_command.py
@@ -168,3 +168,19 @@ class TestConnectCommand:
 
         # assert that the dependencies.yml was created with a pointer to the upstream project
         assert "src_proj_a" in dependency_path.read_text()
+
+    def test_connect_raises_exception_invalid_paths(self, producer_project):
+        """Verify that proving an invalid project path raises the correct error."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "connect",
+                "--project-paths",
+                "totally_bogus_path",
+                copy_source_consumer_project_path,
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "does not contain a dbt project" in result.stdout

--- a/tests/integration/test_contract_command.py
+++ b/tests/integration/test_contract_command.py
@@ -170,3 +170,22 @@ def test_add_contract_read_catalog(start_yml, end_yml, read_catalog, caplog, pro
         assert "Generating catalog with dbt docs generate..." in caplog.text
 
     assert actual == yaml.safe_load(end_yml)
+
+
+def test_command_raises_exception_invalid_paths():
+    """Verify that proving an invalid project path raises the correct error."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "operation",
+            "add-contract",
+            "--select",
+            "shared_model",
+            "--project-path",
+            "tests",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "does not contain a dbt project" in result.stdout

--- a/tests/integration/test_create_group_command.py
+++ b/tests/integration/test_create_group_command.py
@@ -218,3 +218,26 @@ def test_group_owner_properties(name, email, end_group_yml, project):
         del end_group_content["groups"][0]["owner"]["email"]
 
     assert actual == end_group_content
+
+
+def test_command_raises_exception_invalid_paths():
+    """Verify that proving an invalid project path raises the correct error."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "operation",
+            "create-group",
+            "test_group",
+            "--owner-name",
+            "Johnny Spells",
+            "--select",
+            "shared_model",
+            "other_model",
+            "--project-path",
+            "tests",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "does not contain a dbt project" in result.stdout

--- a/tests/integration/test_group_command.py
+++ b/tests/integration/test_group_command.py
@@ -54,3 +54,24 @@ def test_group_command(select, expected_public_contracted_models):
     ]
     assert public_contracted_models == expected_public_contracted_models
     teardown_test_project(dest_path_string)
+
+
+def test_command_raises_exception_invalid_paths():
+    """Verify that proving an invalid project path raises the correct error."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "group",
+            "test_group",
+            "--owner-name",
+            "Teenage Mutant Jinja Turtles",
+            "--select",
+            "foo",
+            "--project-path",
+            "tests",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "does not contain a dbt project" in result.stdout

--- a/tests/integration/test_split_command.py
+++ b/tests/integration/test_split_command.py
@@ -317,3 +317,22 @@ class TestSplitCommand:
         assert x_proj_ref_5 in child_sql
 
         teardown_test_project(dest_project_path)
+
+
+def test_command_raises_exception_invalid_paths():
+    """Verify that proving an invalid project path raises the correct error."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "split",
+            "my_new_project",
+            "--project-path",
+            "tests",
+            "--select",
+            "orders+",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "does not contain a dbt project" in result.stdout

--- a/tests/integration/test_version_command.py
+++ b/tests/integration/test_version_command.py
@@ -156,4 +156,22 @@ def test_add_version_to_invalid_yml(start_yml, start_files, project):
     ]
     result = runner.invoke(cli, base_command, catch_exceptions=True)
     assert result.exit_code == 1
-    # reset the read path to the default in the logic
+
+
+def test_command_raises_exception_invalid_paths():
+    """Verify that proving an invalid project path raises the correct error."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "operation",
+            "add-version",
+            "--select",
+            "shared_model",
+            "--project-path",
+            "tests",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "does not contain a dbt project" in result.stdout


### PR DESCRIPTION
# Description and Motivation
Previously, it was possible for a user to provide a project path that is not real. For instance, running the command in the wrong directory! In this PR, I've added a check to include that a `dbt_project.yml` file is present in the project path, and if not, a `DbtMeshifyException` is raised with a corresponding error message. Along the way, I added tests for each command to confirm that the correct error message is returned if an invalid project path is provided.

Resolves: #87 

# Example

```console
(dbt-meshify-py3.11) > $ dbt-meshify connect --project-paths test-projects/temp_proj/src_proj_a  test-projects/temp_proj/src_proj_b
19:50:17 | ERROR | The provided directory (/Users/nicholas/projects/nicholasyager/dbt-meshify/test-projects/temp_proj/src_proj_a) does not contain a dbt project.
```