### PR TITLE
handle version args for ref updates in sql and python

### DIFF
--- a/tests/unit/test_update_ref_functions.py
+++ b/tests/unit/test_update_ref_functions.py
@@ -11,8 +11,16 @@ simple_model_sql = """
 select * from {{ ref('my_table') }}
 """
 
+simple_model_version_sql = """
+select * from {{ ref('my_table', v=1) }}
+"""
+
 expected_simple_model_sql = """
 select * from {{ ref('upstream_project', 'my_table') }}
+"""
+
+expected_simple_model_version_sql = """
+select * from {{ ref('upstream_project', 'my_table', v=1) }}
 """
 
 simple_model_python = """
@@ -23,10 +31,26 @@ def model(dbt, session):
     return my_sql_model_df
 """
 
+simple_model_version_python = """
+def model(dbt, session):
+
+    my_sql_model_df = dbt.ref('my_table', v=1)
+
+    return my_sql_model_df
+"""
+
 expected_simple_model_python = """
 def model(dbt, session):
 
     my_sql_model_df = dbt.ref('upstream_project', 'my_table')
+
+    return my_sql_model_df
+"""
+
+expected_simple_model_version_python = """
+def model(dbt, session):
+
+    my_sql_model_df = dbt.ref('upstream_project', 'my_table', v=1)
 
     return my_sql_model_df
 """
@@ -46,6 +70,15 @@ class TestRemoveResourceYml:
         )
         assert updated_sql == expected_simple_model_sql
 
+    def test_update_sql_ref_function__versioned(self):
+        reference_updater = ReferenceUpdater(project=MagicMock())
+        updated_sql = reference_updater.update_refs__sql(
+            model_code=simple_model_version_sql,
+            model_name=upstream_model_name,
+            project_name=upstream_project_name,
+        )
+        assert updated_sql == expected_simple_model_version_sql
+
     def test_update_python_ref_function__basic(self):
         reference_updater = ReferenceUpdater(project=MagicMock())
         updated_python = reference_updater.update_refs__python(
@@ -54,3 +87,12 @@ class TestRemoveResourceYml:
             project_name=upstream_project_name,
         )
         assert updated_python == expected_simple_model_python
+
+    def test_update_python_ref_function__versioned(self):
+        reference_updater = ReferenceUpdater(project=MagicMock())
+        updated_python = reference_updater.update_refs__python(
+            model_code=simple_model_version_python,
+            model_name=upstream_model_name,
+            project_name=upstream_project_name,
+        )
+        assert updated_python == expected_simple_model_version_python


### PR DESCRIPTION
This PR properly handles versioned refs when performing the regex replace to add the project argument during splitting. 

Closes #172