### PR TITLE
Feature: Separate the `add-version` command into `add-version` and `bump-version`. Create new `version` command.

### DIFF
--- a/dbt_meshify/change.py
+++ b/dbt_meshify/change.py
@@ -121,6 +121,9 @@ class ChangeSet:
     def __getitem__(self, key) -> Change:
         return self.changes[key]
 
+    def __setitem__(self, key, value: Change) -> None:
+        self.changes[key] = value
+
     def __delitem__(self, key) -> None:
         del self.changes[key]
 

--- a/dbt_meshify/change.py
+++ b/dbt_meshify/change.py
@@ -118,6 +118,12 @@ class ChangeSet:
         """Extend a ChangeSet with an iterable of Changes."""
         self.changes.extend(changes)
 
+    def __getitem__(self, key) -> Change:
+        return self.changes[key]
+
+    def __delitem__(self, key) -> None:
+        del self.changes[key]
+
     def __iter__(self) -> "ChangeSet":
         return self
 

--- a/dbt_meshify/main.py
+++ b/dbt_meshify/main.py
@@ -425,7 +425,7 @@ def version(
     read_catalog,
 ) -> List[ChangeSet]:
     """
-    Add version boilerplate to a selection of models, and then increment the models to the next version.
+    Increment the models to the next version, and create in the initial version if it has not yet been defined.
     """
     path = Path(project_path).expanduser().resolve()
 

--- a/dbt_meshify/main.py
+++ b/dbt_meshify/main.py
@@ -10,7 +10,7 @@ from dbt.contracts.graph.nodes import ModelNode
 from dbt.contracts.graph.unparsed import Owner
 from loguru import logger
 
-from dbt_meshify.change import ChangeSet, EntityType, ResourceChange
+from dbt_meshify.change import ChangeSet, EntityType, FileChange, ResourceChange
 from dbt_meshify.change_set_processor import (
     ChangeSetProcessor,
     ChangeSetProcessorException,
@@ -400,6 +400,91 @@ def bump_version(
                 model=model_node, prerelease=prerelease, defined_in=defined_in
             )
             change_set.extend(changes)
+
+        except Exception as e:
+            raise FatalMeshifyException(f"Error adding version to model: {model_unique_id}. {e}")
+
+    return [change_set]
+
+
+@cli.command(name="version")
+@exclude
+@project_path
+@read_catalog
+@select
+@selector
+@click.option("--prerelease", "--pre", default=False, is_flag=True)
+@click.option("--defined-in", default=None)
+def version(
+    select,
+    exclude,
+    project_path,
+    selector,
+    prerelease: bool,
+    defined_in: Optional[Path],
+    read_catalog,
+) -> List[ChangeSet]:
+    """
+    Add version boilerplate to a selection of models, and then increment the models to the next version.
+    """
+    path = Path(project_path).expanduser().resolve()
+
+    logger.info(f"Reading dbt project at {path}")
+    project = DbtProject.from_directory(path, read_catalog)
+    resources = list(
+        project.select_resources(
+            select=select, exclude=exclude, selector=selector, output_key="unique_id"
+        )
+    )
+    models = filter(lambda x: x.startswith("model"), resources)
+    logger.info(f"Selected {len(resources)} resources: {resources}")
+    logger.info("Adding version to models in selected resources...")
+
+    versioner = ModelVersioner(project=project)
+    change_set = ChangeSet()
+    for model_unique_id in models:
+        try:
+            model_node = project.get_manifest_node(model_unique_id)
+
+            if not isinstance(model_node, ModelNode):
+                continue
+
+            if model_node.version != model_node.latest_version:
+                continue
+
+            add_changes: ChangeSet = versioner.add_version(model=model_node, defined_in=defined_in)
+
+            model_add_change = add_changes[0]
+            file_add_change = add_changes[1]
+
+            if not isinstance(model_add_change, ResourceChange) or not isinstance(
+                file_add_change, FileChange
+            ):
+                raise FatalMeshifyException(
+                    f"Fault in change calculations for model {model_unique_id}"
+                )
+
+            bump_change: ChangeSet = versioner.bump_version(
+                model=model_node,
+                defined_in=defined_in,
+                prerelease=prerelease,
+                model_override=model_add_change.data,
+            )
+
+            # Update the bump change for the model copy to reference the new model path
+            file_bump_change = bump_change[1]
+            if not isinstance(file_bump_change, FileChange):
+                raise FatalMeshifyException(
+                    f"Fault in change calculations for model {model_unique_id}"
+                )
+            file_bump_change.source = file_add_change.path
+            bump_change[1] = file_bump_change
+
+            # We don't need to update the model properties twice. Let's remove the first one form add_changes.
+            del add_changes[0]
+
+            change_set.extend(add_changes)
+            change_set.extend(bump_change)
 
         except Exception as e:
             raise FatalMeshifyException(f"Error adding version to model: {model_unique_id}. {e}")

--- a/dbt_meshify/utilities/linker.py
+++ b/dbt_meshify/utilities/linker.py
@@ -1,17 +1,11 @@
 from dataclasses import dataclass
 from enum import Enum
-from typing import List, Optional, Set, Union
+from typing import Optional, Set, Union
 
 from dbt.contracts.graph.nodes import CompiledNode, ModelNode, SourceDefinition
 from dbt.node_types import AccessType
 
-from dbt_meshify.change import (
-    ChangeSet,
-    EntityType,
-    FileChange,
-    Operation,
-    ResourceChange,
-)
+from dbt_meshify.change import ChangeSet, EntityType, Operation, ResourceChange
 from dbt_meshify.dbt_projects import BaseDbtProject, DbtProject, PathedProject
 from dbt_meshify.utilities.contractor import Contractor
 from dbt_meshify.utilities.dependencies import DependenciesUpdater

--- a/dbt_meshify/utilities/versioner.py
+++ b/dbt_meshify/utilities/versioner.py
@@ -62,7 +62,7 @@ class ModelVersioner:
         except ValueError:
             raise ValueError("Version not an integer, can't increment version.")
 
-    def add_version(self, model: ModelNode, defined_in: Optional[Path] = None):
+    def add_version(self, model: ModelNode, defined_in: Optional[Path] = None) -> ChangeSet:
         """Pass add versioning to an existing model."""
 
         path = self.project.resolve_patch_path(model)

--- a/dbt_meshify/utilities/versioner.py
+++ b/dbt_meshify/utilities/versioner.py
@@ -149,7 +149,7 @@ class ModelVersioner:
 
         # Bump versions
         new_greatest_version_number = greatest_version + 1
-        new_latest_version_number = latest_version if prerelease else new_greatest_version_number
+        new_latest_version_number = latest_version if prerelease else latest_version + 1
 
         # Setup the new version definitions
         new_version_data: Dict[str, Any] = {"v": new_greatest_version_number}

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -5,7 +5,7 @@ For consistency and clarity of the following examples, we're going to use a simp
 We will give a basic example for each command, but to see the full list of additional flags you can add to a given command, check out the [commands page](commands.md).
 
 !!! note
-    One helpful flag that you can add to all of the commands is `--read-catalog`, which will skip the `dbt docs generate` step and instead read the local `catalog.json` file - this will speed up the time it takes to run the `dbt-meshify` commands but relies on your local `catalog.json` file being up-to-date. Alternatively, you can configure this via the `DBT_MESHIFY_READ_CATALOG` environment variable.
+One helpful flag that you can add to all of the commands is `--read-catalog`, which will skip the `dbt docs generate` step and instead read the local `catalog.json` file - this will speed up the time it takes to run the `dbt-meshify` commands but relies on your local `catalog.json` file being up-to-date. Alternatively, you can configure this via the `DBT_MESHIFY_READ_CATALOG` environment variable.
 
 Let's imagine a dbt project with the following models:
 ![dbt dag of models](https://github.com/dave-connors-3/barnold-corp/assets/53586774/3775c540-ddc1-4eae-8587-8a0a9fb48c79)
@@ -28,12 +28,12 @@ dbt-meshify operation create-group sales_analytics --owner-name Ralphie --select
 This will create a new group named "sales_analytics" with the owner "Ralphie" and add all selected models to that group with the appropriate `access` configuration:
 
 - create a new group definition in a `_groups.yml` file:
-![yml file with group defition](https://github.com/dave-connors-3/barnold-corp/assets/53586774/b3fa812a-157f-41b3-842d-c67e59f77298)
+  ![yml file with group defition](https://github.com/dave-connors-3/barnold-corp/assets/53586774/b3fa812a-157f-41b3-842d-c67e59f77298)
 
 - add all selected models to that group with the appropriate `access` config
-    - all models that are only referenced by other models in their _same group_ will have `access: private`
+  - all models that are only referenced by other models in their _same group_ will have `access: private`
     ![int_sales__unioned access set to private](https://github.com/dave-connors-3/barnold-corp/assets/53586774/481010bb-ceed-4feb-a46e-05c185fac4e4)
-    - all other models (those that are referenced by models _outside their group_ or are "leaf" models) will have `access: protected`
+  - all other models (those that are referenced by models _outside their group_ or are "leaf" models) will have `access: protected`
     ![transactions access set to protected](https://github.com/dave-connors-3/mega-corp-big-co-inc/assets/53586774/ad612ca7-2415-429f-aed8-108c4f16f9db)
 
 ### Add/increment model versions
@@ -45,14 +45,15 @@ Let's say you want to add a new version to the customers model, which is current
 You can run the following command:
 
 ```bash
-dbt-meshify operation add-version --select customers
+dbt-meshify version --select customers
 ```
 
-This will add a version to the `customers` model:
+This will add a version to the `customers` model for your current version, and will add a new version for breaking change you wish to implement:
 
 - the `customers.sql` file will be renamed to `customers_v1.sql`
+- a new `customers_v2.sql` file will be created based on `customers_v1.sql`
 - the necessary version configurations will be created (or added to a pre-existing `yml` file)
-![yml file updated with version configs](https://github.com/dave-connors-3/barnold-corp/assets/53586774/c0b12ab7-904e-4590-84aa-7b602a91f53f)
+  ![yml file updated with version configs](https://github.com/dave-connors-3/barnold-corp/assets/53586774/c0b12ab7-904e-4590-84aa-7b602a91f53f)
 
 ### Add contract(s)
 
@@ -68,9 +69,9 @@ dbt-meshify operation add-contract --select stores
 This will add an enforced contract to the `stores` model:
 
 - add a `contract` config and set `enforced: true`
-![yml file updated with added contract config](https://github.com/dave-connors-3/barnold-corp/assets/53586774/bf1ba4e2-76a1-4a65-a0a9-7614487b7d6f)
+  ![yml file updated with added contract config](https://github.com/dave-connors-3/barnold-corp/assets/53586774/bf1ba4e2-76a1-4a65-a0a9-7614487b7d6f)
 - add every column's `name` and `data_type` if not already defined
-![yml file updated with added column names and data_types](https://github.com/dave-connors-3/barnold-corp/assets/53586774/1d989396-2b07-48c5-bcf6-de7eaf02b928)
+  ![yml file updated with added column names and data_types](https://github.com/dave-connors-3/barnold-corp/assets/53586774/1d989396-2b07-48c5-bcf6-de7eaf02b928)
 
 ## Global commands
 
@@ -85,19 +86,19 @@ You can run the following command:
 dbt-meshify group sales_analytics --owner-name Ralphie --select +int_sales__unioned +int_returns__unioned transactions
 ```
 
-This will create a new group named "sales_analytics" with the owner "Ralphie", add all selected models to that group with the appropriate `access` configuration, _and add contracts to the models at the boundary between this group and the rest of the project__:
+This will create a new group named "sales_analytics" with the owner "Ralphie", add all selected models to that group with the appropriate `access` configuration, \_and add contracts to the models at the boundary between this group and the rest of the project\_\_:
 
 - create a new group definition in a `_groups.yml` file
-![yml file with group defition](https://github.com/dave-connors-3/barnold-corp/assets/53586774/b3fa812a-157f-41b3-842d-c67e59f77298)
+  ![yml file with group defition](https://github.com/dave-connors-3/barnold-corp/assets/53586774/b3fa812a-157f-41b3-842d-c67e59f77298)
 - add all selected models to that group with the appropriate `access` config
-    - all models that are only referenced by other models in their _same group_ will have `access: private`
+  - all models that are only referenced by other models in their _same group_ will have `access: private`
     ![int_sales__unioned access set to private](https://github.com/dave-connors-3/barnold-corp/assets/53586774/481010bb-ceed-4feb-a46e-05c185fac4e4)
-    - all other models (those that are referenced by models _outside their group_ or are "leaf" models) will have `access: protected`
+  - all other models (those that are referenced by models _outside their group_ or are "leaf" models) will have `access: protected`
     ![transactions access set to protected](https://github.com/dave-connors-3/mega-corp-big-co-inc/assets/53586774/ad612ca7-2415-429f-aed8-108c4f16f9db)
 - for all `protected` models:
-    - add a `contract` config and set `enforced: true`
+  - add a `contract` config and set `enforced: true`
     ![yml file updated with added contract config for transactions model](https://github.com/dave-connors-3/mega-corp-big-co-inc/assets/53586774/747a7a25-d352-4913-95ed-4c6f72721bbb)
-    - add every column's `name` and `data_type` if not already defined
+  - add every column's `name` and `data_type` if not already defined
     ![yml file updated with added column names and data_types for transactions model](https://github.com/dave-connors-3/barnold-corp/assets/53586774/f6402db9-95f0-4dc3-bc17-5966e79811a4)
 
 ### Split out a new subproject
@@ -114,19 +115,19 @@ dbt-meshify split sales_analytics --select +int_sales__unioned +int_returns__uni
 This will create a new subproject that contains the selected sales analytics models, configure the "edge" models to be `public` and contracted, and replace all dependencies in the downstream project on the upstreams's models with cross-project `ref`s:
 
 - create a new subproject that contains the selected sales analytics models
-![selected models moved to a subproject](https://github.com/dave-connors-3/mega-corp-big-co-inc/assets/53586774/e638d83e-eb24-4f1e-852d-2c058bfedb4f)
+  ![selected models moved to a subproject](https://github.com/dave-connors-3/mega-corp-big-co-inc/assets/53586774/e638d83e-eb24-4f1e-852d-2c058bfedb4f)
 
 - add a `dependencies.yml` to the _downstream_ project (in our case, our new subproject is downstream of the original project because the `transactions` model depends on some of the models that remain in the original project - `stores` and `customers`)
-![add dependencies.yml](https://github.com/dave-connors-3/mega-corp-big-co-inc/assets/53586774/65e47b65-30ca-475f-bfa7-fffb26d85e11)
+  ![add dependencies.yml](https://github.com/dave-connors-3/mega-corp-big-co-inc/assets/53586774/65e47b65-30ca-475f-bfa7-fffb26d85e11)
 - add `access: public` to all "leaf" models (models with no downstream dependencies) and models in the upstream project that are referenced by models in the downstream project
-![customers access set to public](https://github.com/dave-connors-3/mega-corp-big-co-inc/assets/53586774/9e110ca4-40c5-4013-ab89-773b59638320)
+  ![customers access set to public](https://github.com/dave-connors-3/mega-corp-big-co-inc/assets/53586774/9e110ca4-40c5-4013-ab89-773b59638320)
 - for all `public` models:
-    - add a `contract` config and set `enforced: true`
+  - add a `contract` config and set `enforced: true`
     ![yml file updated with added contract config for stores model](https://github.com/dave-connors-3/mega-corp-big-co-inc/assets/53586774/800fc871-ce56-4e80-b746-8bd84aa05574)
-    - add every column's `name` and `data_type` if not already defined
+  - add every column's `name` and `data_type` if not already defined
     ![yml file updated with added column names and data_types for stores model](https://github.com/dave-connors-3/mega-corp-big-co-inc/assets/53586774/48d41e17-0ad3-4a31-863b-1a8646d1d7c9)
 - replace any dependencies in the downstream project on the upstream's models with a cross-project `ref`
-![refs to customers and stores replaced with cross-project ref](https://github.com/dave-connors-3/mega-corp-big-co-inc/assets/53586774/33de63e1-0579-4ac0-9ff4-22099d701b99)
+  ![refs to customers and stores replaced with cross-project ref](https://github.com/dave-connors-3/mega-corp-big-co-inc/assets/53586774/33de63e1-0579-4ac0-9ff4-22099d701b99)
 
 By default, the new subproject will be created in the current directory; however, you can use the `--create-path` flag to create it in any directory you like.
 
@@ -135,9 +136,9 @@ By default, the new subproject will be created in the current directory; however
 Let's look at a slightly modified version of the example we've been working with. Instead of a single dbt project, let's imagine you're starting with two separate dbt projects connected via the "source hack":
 
 - project A contains the following models
-![project A's dag of models](https://github.com/dave-connors-3/mega-corp-big-co-inc/assets/53586774/75771c9c-1fa4-4cc5-b9b9-380f39091031)
+  ![project A's dag of models](https://github.com/dave-connors-3/mega-corp-big-co-inc/assets/53586774/75771c9c-1fa4-4cc5-b9b9-380f39091031)
 - project B contains the following models
-![project B's dag of models](https://github.com/dave-connors-3/mega-corp-big-co-inc/assets/53586774/a94657e5-c9bc-4b8b-ada5-63887bfd0ba3)
+  ![project B's dag of models](https://github.com/dave-connors-3/mega-corp-big-co-inc/assets/53586774/a94657e5-c9bc-4b8b-ada5-63887bfd0ba3)
 
 We call this type of multi-project configuration the "source hack" because there are models generated by project A (`stores` and `customers`) that are defined as sources in project B.
 
@@ -152,15 +153,15 @@ dbt-meshify connect --project-paths path/to/project_a path/to/project_b
 This will make the upstream project a dependency for the downstream project, configure the "edge" models to be `public` and contracted, and replace all dependencies in the downstream project on the upstreams's models with cross-project `ref`s:
 
 - add a `dependencies.yml` to the _downstream_ project (in our case, project B is downstream of project A because the `transactions` model depends on some of the models that are generated by project A - `stores` and `customers`)
-![dependencies.yml](https://github.com/dave-connors-3/mega-corp-big-co-inc/assets/53586774/0dfa6e3d-5ccf-4d85-affa-0f2bda9c6ef4)
+  ![dependencies.yml](https://github.com/dave-connors-3/mega-corp-big-co-inc/assets/53586774/0dfa6e3d-5ccf-4d85-affa-0f2bda9c6ef4)
 - add `access: public` to all models in the upstream project that are referenced by models in the downstream project
-![customers access set to public](https://github.com/dave-connors-3/mega-corp-big-co-inc/assets/53586774/9e110ca4-40c5-4013-ab89-773b59638320)
+  ![customers access set to public](https://github.com/dave-connors-3/mega-corp-big-co-inc/assets/53586774/9e110ca4-40c5-4013-ab89-773b59638320)
 - for all `public` models:
-    - add a `contract` config and set `enforced: true`
+  - add a `contract` config and set `enforced: true`
     ![yml file updated with added contract config for stores model](https://github.com/dave-connors-3/mega-corp-big-co-inc/assets/53586774/800fc871-ce56-4e80-b746-8bd84aa05574)
-    - add every column's `name` and `data_type` if not already defined
+  - add every column's `name` and `data_type` if not already defined
     ![yml file updated with added column names and data_types for stores model](https://github.com/dave-connors-3/mega-corp-big-co-inc/assets/53586774/48d41e17-0ad3-4a31-863b-1a8646d1d7c9)
 - replace any dependencies in the downstream project on the upstream's models with a cross-project `ref`
-![customers and stores sources replaced with cross-project ref](https://github.com/dave-connors-3/mega-corp-big-co-inc/assets/53586774/24d72b99-fbf1-489d-bda8-ccaea267981b)
+  ![customers and stores sources replaced with cross-project ref](https://github.com/dave-connors-3/mega-corp-big-co-inc/assets/53586774/24d72b99-fbf1-489d-bda8-ccaea267981b)
 - remove unnecessary sources
-![unnecessary sources have been deleted](https://github.com/dave-connors-3/mega-corp-big-co-inc/assets/53586774/fe657aa5-f14e-461e-bacd-30ce55451cb6)
+  ![unnecessary sources have been deleted](https://github.com/dave-connors-3/mega-corp-big-co-inc/assets/53586774/fe657aa5-f14e-461e-bacd-30ce55451cb6)

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,11 +4,11 @@
 
 These dbt mesh features include:
 
-1. __[Groups](https://docs.getdbt.com/docs/build/groups)__ - group your models into logical sets.
-2. __[Contracts](https://docs.getdbt.com/docs/collaborate/govern/model-contracts)__ - add model contracts to your models to ensure consistent data shape.
-3. __[Access](https://docs.getdbt.com/docs/collaborate/govern/model-access)__ - control the `access` level of models within groups
-4. __[Versions](https://docs.getdbt.com/docs/collaborate/govern/model-versions)__ - create and increment versions of particular models.
-5. __[Project dependencies](https://docs.getdbt.com/docs/collaborate/govern/project-dependencies)__ - split a monolithic dbt project into component projects, or connect multiple pre-existing dbt projects using cross-project `ref`.
+1. **[Groups](https://docs.getdbt.com/docs/build/groups)** - group your models into logical sets.
+2. **[Contracts](https://docs.getdbt.com/docs/collaborate/govern/model-contracts)** - add model contracts to your models to ensure consistent data shape.
+3. **[Access](https://docs.getdbt.com/docs/collaborate/govern/model-access)** - control the `access` level of models within groups
+4. **[Versions](https://docs.getdbt.com/docs/collaborate/govern/model-versions)** - create and increment versions of particular models.
+5. **[Project dependencies](https://docs.getdbt.com/docs/collaborate/govern/project-dependencies)** - split a monolithic dbt project into component projects, or connect multiple pre-existing dbt projects using cross-project `ref`.
 
 This package leverages the dbt-core Python API to allow users to use standard dbt selection syntax for each of the commands in this package (unless otherwise noted). See details on each of the specific commands available on the [commands page](commands.md).
 
@@ -22,8 +22,7 @@ This package consists of **component** and **global** commands - so you can deci
 
 The **component** commands allow you to do a single step at a time and begin with `dbt-meshify operation`. For example, if you wanted to add a new version to a model, you would run something like `dbt-meshify operation add-version --select fct_orders`. This command would:
 
-1. add a new version to `fct_orders`
-
+1. add version configuration values to `fct_orders`
 
 and that's it!
 
@@ -51,7 +50,7 @@ For further information, check out the available [commands](commands.md) or read
 
 There are a handful of known edge cases that this package does not automatically handle. In these cases, we recommend doing a manual check to make sure you've handled these appropriately:
 
-| edge case | manual check |
-|-----------|--------------|
-|`dbt-meshify split` copies over the entire contents of the `packages.yml` file from the original project to the new subproject | remove unnecessary packages from each project |
-| `dbt-meshify split` makes a copy of all necessary macros from the original project to the new subproject | consider creating a private "macros only" project to install as a package into all of your other projects, instead of maintaining duplicate copies of shared macros |
+| edge case                                                                                                                      | manual check                                                                                                                                                        |
+| ------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dbt-meshify split` copies over the entire contents of the `packages.yml` file from the original project to the new subproject | remove unnecessary packages from each project                                                                                                                       |
+| `dbt-meshify split` makes a copy of all necessary macros from the original project to the new subproject                       | consider creating a private "macros only" project to install as a package into all of your other projects, instead of maintaining duplicate copies of shared macros |

--- a/tests/unit/test_add_version_to_yml.py
+++ b/tests/unit/test_add_version_to_yml.py
@@ -39,7 +39,7 @@ class TestAddContractToYML:
         file_manager.read_file.return_value = input
 
         versioner = ModelVersioner(project=project, file_manager=file_manager)
-        changes = list(versioner.generate_version(model))
+        changes = list(versioner.add_version(model))
         yml_dict = ResourceFileEditor.update_resource(properties=input, change=changes[0])
 
         assert yml_dict == read_yml(expected_versioned_model_yml_no_yml)
@@ -50,7 +50,7 @@ class TestAddContractToYML:
         file_manager.read_file.return_value = input
 
         versioner = ModelVersioner(project=project, file_manager=file_manager)
-        changes = list(versioner.generate_version(model))
+        changes = list(versioner.add_version(model))
         yml_dict = ResourceFileEditor.update_resource(properties=input, change=changes[0])
 
         assert yml_dict == read_yml(expected_versioned_model_yml_no_version)
@@ -59,7 +59,7 @@ class TestAddContractToYML:
         self, model, project, file_manager  # noqa: F811
     ):
         versioner = ModelVersioner(project=project, file_manager=file_manager)
-        changes = list(versioner.generate_version(model))
+        changes = list(versioner.bump_version(model))
         yml_dict = ResourceFileEditor.update_resource(
             properties=read_yml(model_yml_increment_version), change=changes[0]
         )
@@ -70,7 +70,7 @@ class TestAddContractToYML:
         self, model, project, file_manager  # noqa: F811
     ):
         versioner = ModelVersioner(project=project, file_manager=file_manager)
-        changes = list(versioner.generate_version(model, prerelease=True))
+        changes = list(versioner.bump_version(model, prerelease=True))
         yml_dict = ResourceFileEditor.update_resource(
             properties=read_yml(model_yml_increment_version), change=changes[0]
         )
@@ -81,7 +81,7 @@ class TestAddContractToYML:
         self, model, project, file_manager  # noqa: F811
     ):
         versioner = ModelVersioner(project=project, file_manager=file_manager)
-        changes = list(versioner.generate_version(model, defined_in="daves_model"))
+        changes = list(versioner.bump_version(model, defined_in="daves_model"))
         yml_dict = ResourceFileEditor.update_resource(
             properties=read_yml(model_yml_increment_version), change=changes[0]
         )


### PR DESCRIPTION
# Description of Changes
This PR makes some lofty changes to how versions are handled in dbt-meshify.
1. The `operation add-version` command ONLY adds version boilerplate for models that are currently unversioned.
2. A new `operation bump-version` command handles bumping versions for models, including prereleases and file operations.
3. A new `version` command, which does both! In this case, previously unversioned models will have version boilerplate added, and then the version will be incremented on top.

Resolves: #168