### PR TITLE
pass `--read-catalog` to both `group` subcommands

### DIFF
--- a/dbt_meshify/main.py
+++ b/dbt_meshify/main.py
@@ -629,6 +629,7 @@ def group(
             ]
         ),
         project_path=project_path,
+        read_catalog=read_catalog,
     )
 
     return group_changes + contract_changes

--- a/tests/integration/test_group_command.py
+++ b/tests/integration/test_group_command.py
@@ -75,3 +75,27 @@ def test_command_raises_exception_invalid_paths():
 
     assert result.exit_code != 0
     assert "does not contain a dbt project" in result.stdout
+
+
+def test_read_catalog_group():
+    """Verify that proving an invalid project path raises the correct error."""
+    setup_test_project(src_path_string, dest_path_string)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "group",
+            "test_group",
+            "--owner-name",
+            "Teenage Mutant Jinja Turtles",
+            "--select",
+            "foo",
+            "--project-path",
+            "tests",
+            "--read-catalog",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "dbt docs generate" not in result.stdout
+    teardown_test_project(dest_path_string)


### PR DESCRIPTION
closes #181

Makes sure we properly pass the read catalog flag to the second invocation nested in `dbt-meshify group` !