### PR TITLE
176 clean before deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ venv/
 __pycache__/
 # IDEs
 .idea/
+.vscode/
 
 **/database.db
 logs/

--- a/dbt_meshify/dbt.py
+++ b/dbt_meshify/dbt.py
@@ -22,7 +22,8 @@ class Dbt:
         result = self.dbt_runner.invoke(runner_args if runner_args else [])
         if not result.success and result.exception:
             if isinstance(result.exception, UninstalledPackagesFoundError):
-                logger.debug("Project missing packages, running dbt deps...")
+                logger.debug("Project missing packages, running dbt clean and deps...")
+                self.dbt_runner.invoke(["clean"])
                 self.dbt_runner.invoke(["deps"])
                 result = self.dbt_runner.invoke(runner_args if runner_args else [])
 

--- a/dbt_meshify/dbt.py
+++ b/dbt_meshify/dbt.py
@@ -22,7 +22,7 @@ class Dbt:
         result = self.dbt_runner.invoke(runner_args if runner_args else [])
         if not result.success and result.exception:
             if isinstance(result.exception, UninstalledPackagesFoundError):
-                logger.debug("Project missing packages, running dbt clean and deps...")
+                logger.debug("Project missing packages, running dbt clean and dbt deps...")
                 self.dbt_runner.invoke(["clean"])
                 self.dbt_runner.invoke(["deps"])
                 result = self.dbt_runner.invoke(runner_args if runner_args else [])


### PR DESCRIPTION
Fixes #176 

Runs `dbt clean` before `dbt deps` when the packages installed don't match the packages in `packages.yml`

One of the use cases where clean is required for example is when people used to use `dbt_metrics` and then move to 1.6. Removing the package from `packages.yml` doesn't remove it from `dbt_packages` and still raise compilation errors.