### PR TITLE
pass args as string

### DIFF
--- a/dbt_meshify/dbt_projects.py
+++ b/dbt_meshify/dbt_projects.py
@@ -322,11 +322,15 @@ class DbtProject(BaseDbtProject, PathedProject):
         args = []
         # import pdb; pdb.set_trace()
         if select:
-            args = ["--select", " ".join(select)]
+            args = ["--select", " ".join(select) if not isinstance(select, str) else select]
         if exclude:
-            args.extend(["--exclude", " ".join(exclude)])
+            args.extend(
+                ["--exclude", " ".join(exclude) if not isinstance(exclude, str) else exclude]
+            )
         if selector:
-            args.extend(["--selector", " ".join(selector)])
+            args.extend(
+                ["--selector", " ".join(selector) if not isinstance(selector, str) else selector]
+            )
 
         results = self.dbt.ls(self.path, args, output_key=output_key)
         if output_key:

--- a/dbt_meshify/dbt_projects.py
+++ b/dbt_meshify/dbt_projects.py
@@ -320,12 +320,13 @@ class DbtProject(BaseDbtProject, PathedProject):
     ) -> Set[str]:
         """Select dbt resources using NodeSelection syntax"""
         args = []
+        # import pdb; pdb.set_trace()
         if select:
-            args = ["--select", select]
+            args = ["--select", " ".join(select)]
         if exclude:
-            args.extend(["--exclude", exclude])
+            args.extend(["--exclude", " ".join(exclude)])
         if selector:
-            args.extend(["--selector", selector])
+            args.extend(["--selector", " ".join(selector)])
 
         results = self.dbt.ls(self.path, args, output_key=output_key)
         if output_key:


### PR DESCRIPTION
This PR makes dbt-meshify compatible with the latest dbt core release by passing any multiselect args to `dbt ls` as a single string separated by spaces, which is accepted by the parser in dbt core. 

My initial implementation was to convert the tuple that is returned from our meshify command to a list, but that raised the same error as before -- if appears the type check we were discussing in our sync is not relevant for the `--select` flag, and is used for other flags. 

I tested on 1.6.3+, and these changes appear to work across versions