### PR TITLE
Case sensitivity

### DIFF
--- a/dbt_meshify/utilities/contractor.py
+++ b/dbt_meshify/utilities/contractor.py
@@ -17,7 +17,6 @@ class Contractor:
 
         # create a mapping of the column name to its representation in the yml file to maintain the original case
         original_case = {column_name.lower(): column_name for column_name in model.columns.keys()}
-        print(original_case)
 
         if not model_catalog or not model_catalog.columns:
             columns = None

--- a/dbt_meshify/utilities/contractor.py
+++ b/dbt_meshify/utilities/contractor.py
@@ -15,11 +15,18 @@ class Contractor:
         """Generate a ChangeSet that adds a contract to a Model."""
         model_catalog = self.project.get_catalog_entry(model.unique_id)
 
+        # create a mapping of the column name to its representation in the yml file to maintain the original case
+        original_case = {column_name.lower(): column_name for column_name in model.columns.keys()}
+        print(original_case)
+
         if not model_catalog or not model_catalog.columns:
             columns = None
         else:
             columns = [
-                {"name": name.lower(), "data_type": value.type.lower()}
+                {
+                    "name": original_case.get(name.lower()) or name.lower(),
+                    "data_type": value.type.lower(),
+                }
                 for name, value in model_catalog.columns.items()
             ]
 

--- a/tests/sql_and_yml_fixtures.py
+++ b/tests/sql_and_yml_fixtures.py
@@ -56,6 +56,18 @@ models:
       - name: colleague
         description: "this is the colleague column"
 """
+
+model_yml_all_col_all_caps = """
+models:
+  - name: shared_model
+    description: "this is a test model"
+    columns:
+      - name: ID
+        description: "this is the id column"
+      - name: COLLEAGUE
+        description: "this is the colleague column"
+"""
+
 expected_contract_yml_no_col = """
 models:
   - name: shared_model
@@ -134,6 +146,22 @@ models:
         description: "this is the id column"
         data_type: integer
       - name: colleague
+        description: "this is the colleague column"
+        data_type: varchar
+"""
+
+expected_contract_yml_all_col_all_caps = """
+models:
+  - name: shared_model
+    description: "this is a test model"
+    config:
+      contract:
+        enforced: true
+    columns:
+      - name: ID
+        description: "this is the id column"
+        data_type: integer
+      - name: COLLEAGUE
         description: "this is the colleague column"
         data_type: varchar
 """


### PR DESCRIPTION
closes #190 

As reported, when creating a contract, all column names are currently standardized to lowercase, even if the column was in uppercase in the original yml, leading to unintended duplications/overwriting. This PR adds a step to the Contractor class to maintain the original casing of each of the columns from the yml entry. Anything not defined in yml, but present in the catalog will continue to be lowercased. 

I could not figure out a clean way to pass dynamic column content to our pytest fixture in the unit tests, so i created a new model fixture that included the column specifications. I think that's a big code smelly, so open to suggestions. 