### PR TITLE
Fix: The `group` command will check for existing group file paths.

### DIFF
--- a/dbt_meshify/dbt_projects.py
+++ b/dbt_meshify/dbt_projects.py
@@ -3,7 +3,7 @@ import hashlib
 import json
 import os
 from pathlib import Path
-from typing import Any, Dict, MutableMapping, Optional, Set, Union
+from typing import Any, Dict, List, MutableMapping, Optional, Set, Union
 
 import yaml
 from dbt.contracts.graph.manifest import Manifest
@@ -309,6 +309,7 @@ class DbtProject(BaseDbtProject, PathedProject):
         self.path = path
         self.dbt = dbt
         resources = self.select_resources(output_key="unique_id")
+        self._group_definition_files: Optional[List[Path]] = None
 
         super().__init__(manifest, project, catalog, name, resources)
         self.jinja_blocks: Dict[str, JinjaBlock] = self.find_jinja_blocks()
@@ -389,6 +390,23 @@ class DbtProject(BaseDbtProject, PathedProject):
         self.register_relationship(project_name, subproject_resources)
 
         return subproject
+
+    @property
+    def group_definition_files(self) -> List[Path]:
+        """A list of files that contain group definitions, in order of how many groups are present."""
+
+        if self._group_definition_files is not None:
+            return self._group_definition_files
+
+        paths: Dict[Path, int] = {}
+        for group in self.manifest.groups.values():
+            path = self.path / Path(group.original_file_path)
+            paths[path] = paths.get(path, 0) + 1
+
+        self._group_definition_files = list(
+            map(lambda x: x[0], sorted(paths.items(), key=lambda x: x[1]))
+        )
+        return self._group_definition_files
 
 
 class DbtSubProject(BaseDbtProject, PathedProject):

--- a/dbt_meshify/dbt_projects.py
+++ b/dbt_meshify/dbt_projects.py
@@ -398,14 +398,11 @@ class DbtProject(BaseDbtProject, PathedProject):
         if self._group_definition_files is not None:
             return self._group_definition_files
 
-        paths: Dict[Path, int] = {}
-        for group in self.manifest.groups.values():
-            path = self.path / Path(group.original_file_path)
-            paths[path] = paths.get(path, 0) + 1
+        paths: Set[Path] = {
+            self.path / Path(group.original_file_path) for group in self.manifest.groups.values()
+        }
+        self._group_definition_files = list(paths)
 
-        self._group_definition_files = list(
-            map(lambda x: x[0], sorted(paths.items(), key=lambda x: x[1]))
-        )
         return self._group_definition_files
 
 

--- a/dbt_meshify/main.py
+++ b/dbt_meshify/main.py
@@ -547,7 +547,7 @@ def create_group(
     project = DbtProject.from_directory(path, read_catalog)
 
     if group_yml_path is None:
-        existing_paths = project.group_definition_files()
+        existing_paths = project.group_definition_files
         if len(existing_paths) > 1:
             raise FatalMeshifyException(
                 "Unable to pick which group YAML file to use. Please specify one using the --group-yml-path argument."

--- a/dbt_meshify/main.py
+++ b/dbt_meshify/main.py
@@ -547,7 +547,15 @@ def create_group(
     project = DbtProject.from_directory(path, read_catalog)
 
     if group_yml_path is None:
-        group_yml_path = (path / Path("models/_groups.yml")).resolve()
+        existing_paths = project.group_definition_files()
+        if len(existing_paths) > 1:
+            raise FatalMeshifyException(
+                "Unable to pick which group YAML file to use. Please specify one using the --group-yml-path argument."
+            )
+        if len(existing_paths) == 1:
+            group_yml_path = existing_paths[0]
+        else:
+            group_yml_path = (path / Path("models/_groups.yml")).resolve()
     else:
         group_yml_path = Path(group_yml_path).resolve()
     logger.info(f"Creating new model group in file {group_yml_path.name}")


### PR DESCRIPTION
# Description and Motivation
There was a small defect in `dbt-meshify`, in which the tool would ignore existing files that define groups, instead always defaulting to `_group.yml`. The desired behavior would be to default to a single file that already contains groups if one exists. To that end, I've implemented a check that finds all files that define groups, and if there is one and only one, it will default to that file. If there are none, it will use `_groups.yml`. If there are multiple, it will raise a fatal error and prompt the user to provide a `--group-file-yaml` path.

Along the way, I also added tests to confirm that the functionality works as expected.

Resolves: #188 