### PR TITLE
Fix example command for adding a version

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -45,7 +45,7 @@ Let's say you want to add a new version to the customers model, which is current
 You can run the following command:
 
 ```bash
-dbt-meshify version --select customers
+dbt-meshify operation add-version --select customers
 ```
 
 This will add a version to the `customers` model for your current version, and will add a new version for breaking change you wish to implement:


### PR DESCRIPTION
### Version

```shell
$ pip show dbt-meshify 
Name: dbt-meshify
Version: 0.5.2
```

### Current behavior

```shell
$ dbt-meshify version --select customers             

Usage: dbt-meshify [OPTIONS] COMMAND [ARGS]...
Try 'dbt-meshify --help' for help.

Error: No such command 'version'.
```

### Expected behavior

```shell
$ dbt-meshify operation add-version --select customers

Add version 1 to the customers model where none existed previously.
```