### PR TITLE
Feature: Add  a `--version` flag to aid in debugging

### DIFF
--- a/dbt_meshify/cli.py
+++ b/dbt_meshify/cli.py
@@ -116,7 +116,7 @@ def owner(func):
 
     @functools.wraps(func)
     def wrapper_decorator(*args, **kwargs):
-        if kwargs.get('owner_name') is None and kwargs.get('owner_email') is None:
+        if kwargs.get("owner_name") is None and kwargs.get("owner_email") is None:
             raise click.UsageError(
                 "Groups require an Owner to be defined using --owner-name and/or --owner-email."
             )
@@ -136,3 +136,10 @@ class TupleCompatibleCommand(click.Command):
         pieces = self.collect_usage_pieces(ctx)
         pieces = pieces[1:] + [pieces[0]]
         formatter.write_usage(ctx.command_path, " ".join(pieces))
+
+
+def get_version() -> str:
+    """Get the current package version number."""
+    import importlib.metadata
+
+    return importlib.metadata.version("dbt-meshify")

--- a/dbt_meshify/main.py
+++ b/dbt_meshify/main.py
@@ -25,6 +25,7 @@ from .cli import (
     create_path,
     exclude,
     exclude_projects,
+    get_version,
     group_yml_path,
     latest,
     owner,
@@ -72,14 +73,26 @@ def logger_operation_level_filter(record):
 
 
 # define cli group
-@click.group()
+@click.group(invoke_without_command=True)
 @click.option("--dry-run", is_flag=True)
 @click.option("--debug", is_flag=True)
-def cli(dry_run: bool, debug: bool):
+@click.option("--version", is_flag=True, help="Show version information and exit")
+@click.pass_context
+def cli(ctx, dry_run: bool, debug: bool, version: bool):
     log_level = "DEBUG" if debug else "INFO"
 
     logger.add(sys.stdout, format=log_format, filter=logger_log_level_filter, level=log_level)
     logger.add(sys.stdout, format=operation_format, filter=logger_operation_level_filter)
+
+    # If the --version flag has been provided, print the version number and exit.
+    if version:
+        print(get_version())
+        exit(0)
+
+    # If a command has not been provided, print the help text and exit.
+    if ctx.invoked_subcommand is None:
+        print(ctx.get_help())
+        exit(0)
 
 
 @cli.result_callback()

--- a/tests/integration/test_cli_group.py
+++ b/tests/integration/test_cli_group.py
@@ -27,5 +27,5 @@ def test_no_command_prints_help():
 
     assert result.exit_code == 0
 
-    help_result = result = runner.invoke(cli, ["--help"])
+    help_result = runner.invoke(cli, ["--help"])
     assert result.stdout == help_result.stdout

--- a/tests/integration/test_cli_group.py
+++ b/tests/integration/test_cli_group.py
@@ -1,0 +1,31 @@
+from click.testing import CliRunner
+
+from dbt_meshify.cli import get_version
+from dbt_meshify.main import cli
+
+
+def test_version_option():
+    """When the --version option is passed, meshify returns the version and exits."""
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "--version",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert result.stdout.rstrip() == get_version()
+
+
+def test_no_command_prints_help():
+    """When an invoked subcommand is not provided, print the help and exit."""
+
+    runner = CliRunner()
+    result = runner.invoke(cli)
+
+    assert result.exit_code == 0
+
+    help_result = result = runner.invoke(cli, ["--help"])
+    assert result.stdout == help_result.stdout


### PR DESCRIPTION
# Description and motivation
As mentioned in #198, there is a distinct need to have a `--version` flag added to `dbt-meshify` to make it easier for users to identify which version of `dbt-meshify` they have installed. This PR adds this functionality, such that running `dbt-meshify --version` will print the current version number from the package information (as stored w/in the internals of python), and exit.

To accomplish this, I added the new option, and then added the `invoke_without_command=True` argument to `click.group()` to allow us to run code in the `cli` group when a command has not been provided. I then manually implemented a default check to print help text if a subcommand has not been provided.

Resolves: #200 

## Examples

```console
$ dbt-meshify --version
0.5.2                 
```


```console
$ dbt-meshify
Usage: dbt-meshify [OPTIONS] COMMAND [ARGS]...

Options:
  --dry-run
  --debug
  --version  Show version information and exit
  --help     Show this message and exit.

Commands:
  connect    Connects multiple dbt projects together by adding all...
  group      Creates a new dbt group based on the selection syntax...
  operation  Set of subcommands for performing mesh operations on dbt...
  split      Splits out a new subproject from a dbt project by adding all...
  version    Increment the models to the next version, and create in the...          
```