### PR TITLE
Feature: Use dbt-core starter project as baseline for split projects

### DIFF
--- a/dbt_meshify/change.py
+++ b/dbt_meshify/change.py
@@ -2,7 +2,7 @@ import dataclasses
 import os
 from enum import Enum
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Protocol
+from typing import Callable, Dict, Iterable, List, Optional, Protocol
 
 
 class Operation(str, Enum):
@@ -46,6 +46,7 @@ class EntityType(str, Enum):
     SemanticModel = "semantic_model"
     Project = "project"
     Code = "code"
+    Directory = "directory"
 
     def pluralize(self) -> str:
         if self is self.Analysis:
@@ -95,6 +96,14 @@ class ResourceChange(BaseChange):
             f"`{self.source_name + '.' if self.source_name else ''}{self.identifier}` "
             f"{prepositions[self.operation]} {self.path.relative_to(os.getcwd())}"
         )
+
+
+@dataclasses.dataclass
+class DirectoryChange(BaseChange):
+    """A DirectoryChange represents a unit of work that should be performed on a Directory in a dbt project."""
+
+    source: Optional[Path] = None
+    ignore_function: Optional[Callable] = None
 
 
 @dataclasses.dataclass

--- a/dbt_meshify/change_set_processor.py
+++ b/dbt_meshify/change_set_processor.py
@@ -4,7 +4,14 @@ from typing import Iterable
 from loguru import logger
 
 from dbt_meshify.change import Change, ChangeSet, EntityType
-from dbt_meshify.storage.file_content_editors import RawFileEditor, ResourceFileEditor
+from dbt_meshify.storage.file_content_editors import (
+    DirectoryEditor,
+    RawFileEditor,
+    ResourceFileEditor,
+)
+
+# Enumeration of valid File Editors
+FILE_EDITORS = {EntityType.Code: RawFileEditor, EntityType.Directory: DirectoryEditor}
 
 
 class ChangeSetProcessorException(BaseException):
@@ -24,9 +31,7 @@ class ChangeSetProcessor:
 
     def write(self, change: Change) -> None:
         """Commit a Change to the file system."""
-        file_editor = (
-            RawFileEditor() if change.entity_type == EntityType.Code else ResourceFileEditor()
-        )
+        file_editor = FILE_EDITORS.get(change.entity_type, ResourceFileEditor)()
 
         file_editor.__getattribute__(change.operation)(change)
 

--- a/dbt_meshify/storage/dbt_project_editors.py
+++ b/dbt_meshify/storage/dbt_project_editors.py
@@ -126,9 +126,6 @@ class DbtSubprojectCreator:
 
         contents = self.subproject.project.to_dict()
 
-        # was getting a weird serialization error from ruamel on this value
-        # it's been deprecated, so no reason to keep it
-        # contents.pop("version")
         # this one appears in the project yml, but i don't think it should be written
         contents.pop("query-comment")
         contents = filter_empty_dict_items(contents)

--- a/dbt_meshify/storage/file_content_editors.py
+++ b/dbt_meshify/storage/file_content_editors.py
@@ -2,9 +2,13 @@ from typing import Any, Dict, List, Optional
 
 from loguru import logger
 
-from dbt_meshify.change import EntityType, FileChange, ResourceChange
+from dbt_meshify.change import DirectoryChange, EntityType, FileChange, ResourceChange
 from dbt_meshify.exceptions import FileEditorException
-from dbt_meshify.storage.file_manager import RawFileManager, YAMLFileManager
+from dbt_meshify.storage.file_manager import (
+    DirectoryManager,
+    RawFileManager,
+    YAMLFileManager,
+)
 
 
 class NamedList(dict):
@@ -87,6 +91,18 @@ def safe_update(original: Dict[Any, Any], update: Dict[Any, Any]) -> Dict[Any, A
         elif value is not None:
             original[key] = value
     return original
+
+
+class DirectoryEditor:
+    """A helper class used to perform filesystem operations on Directories"""
+
+    @staticmethod
+    def copy(change: DirectoryChange):
+        """Copy a file from one location to another."""
+        if change.source is None:
+            raise FileEditorException("None source value provided in Copy operation.")
+
+        DirectoryManager.copy_directory(change.source, change.path, change.ignore_function)
 
 
 class RawFileEditor:

--- a/dbt_meshify/storage/file_manager.py
+++ b/dbt_meshify/storage/file_manager.py
@@ -3,7 +3,7 @@
 
 import shutil
 from pathlib import Path
-from typing import Any, Dict, List, Protocol
+from typing import Any, Callable, Dict, List, Optional, Protocol
 
 from dbt.contracts.util import Identifier
 from ruamel.yaml import YAML
@@ -41,6 +41,21 @@ class FileManager(Protocol):
     def write_file(self, path: Path, content: Any) -> None:
         """Write content to a file."""
         pass
+
+
+class DirectoryManager:
+    """DirectoryManager is a FileManager for operating on directories in the filesystem"""
+
+    @staticmethod
+    def copy_directory(
+        source_path: Path, target_path: Path, ignore_function: Optional[Callable] = None
+    ) -> None:
+        """Copy a directory from source to target"""
+
+        if not target_path.parent.exists():
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+
+        shutil.copytree(source_path, target_path, symlinks=True, ignore=ignore_function)
 
 
 class RawFileManager:

--- a/dbt_meshify/storage/file_manager.py
+++ b/dbt_meshify/storage/file_manager.py
@@ -18,6 +18,7 @@ class DbtYAML(YAML):
         self.preserve_quotes = True
         self.width = 4096
         self.indent(mapping=2, sequence=4, offset=2)
+        self.default_flow_style = False
 
     def dump(self, data, stream=None, **kw):
         inefficient = False


### PR DESCRIPTION
# Description and motivation
A common question for users of dbt-meshify is "why does the split project look ... odd?" In most cases, this is a byproduct of the existing `split` command creating only necessary directories and files in the split project. While functional, this is not the ideal experience for users.

This PR updates our method for creating projects, to instead start by creating a new starter project in the target directory, add all directories and files of interest, and then update the starter `dbt_project.yml` file using the sub-project's configuration information. The benefits to this approach are:
1. Sub-projects have all the standard files and directories for a dbt project.
2. The sub-project have a familiar `dbt_project.yml` file experience.

Along the way, I also implemented the following:
1. Tests that confirm the presence of standard dbt directories in sub-projects on creation.
2. Added a new Change type (`Directorychange`), file manager (`DirectoryManager`) and directory editor (`DirectoryEditor`) for interacting with directory structures instead of files. Some minor refactoring was implemented along the way.

Resolves: #124 
Resolves: #153 


## Example `dbt_project.yml`

```yml
# Name your project! Project names should contain only lowercase characters
# and underscores. A good package name should reflect your organization's
# name or the intended use of these models
name: 'customers'
version: '1.0.0'
config-version: 2

# This setting configures which "profile" dbt uses for this project.
profile: 'split_proj'

# These configurations specify where dbt should look for different types of files.
# The `model-paths` config, for example, states that models in this project can be
# found in the "models/" directory. You probably won't need to change these!
model-paths:
  - models
analysis-paths:
  - analyses
test-paths:
  - tests
seed-paths:
  - seeds
  - jaffle_data
macro-paths:
  - macros
snapshot-paths:
  - snapshots

clean-targets:         # directories to be removed by `dbt clean`
  - target
  - dbt_packages
models:
  customers:
    +on_schema_change: append_new_columns
    example:
      +materialized: view
require-dbt-version:
  - '>=1.7.0'
  - <1.8.0
seeds:
  +schema: jaffle_raw
vars:
  truncate_timespan_to: '{{ current_timestamp() }}'

```

Note the preserved comments and formatting in the bog-standard parts of the YAML file.