### PR TITLE
fix for spaces and quotes in jinja block matching

### DIFF
--- a/dbt_meshify/storage/jinja_blocks.py
+++ b/dbt_meshify/storage/jinja_blocks.py
@@ -24,7 +24,8 @@ class JinjaBlock:
         end_line = None
 
         for match in re.finditer(
-            r"{%-?\s+" + block_type + r"\s+" + name + r"([(a-zA-Z0-9=,_ )]*)\s-?%}",
+            r"{%-?\s*" + block_type + r"\s*" + name + r"\s*([(a-zA-Z0-9=,_ \'\")]*)\s*-?%}",
+            # r"\s*\((.*?)\)\s*-?%}"
             file_content,
             re.MULTILINE,
         ):
@@ -36,7 +37,7 @@ class JinjaBlock:
             raise Exception(f"Unable to find a {block_type} block with the name {name}.")
 
         for match in re.finditer(
-            r"{%-?\s+end" + block_type + r"\s+-?%}", file_content, re.MULTILINE
+            r"{%-?\s*end" + block_type + r"\s*-?%}", file_content, re.MULTILINE
         ):
             end = match.span()[1]  # .span() gives tuple (start, end)
             new_end_line = end  # file_content[:start].count("\n")

--- a/dbt_meshify/utilities/versioner.py
+++ b/dbt_meshify/utilities/versioner.py
@@ -171,7 +171,6 @@ class ModelVersioner:
             LatestVersionBehavior.Latest: greatest_version + 1,
         }
 
-
         new_latest_version_number = latest_version_number_map[latest_version_behavior]
         # Setup the new version definitions
         new_version_data: Dict[str, Any] = {"v": new_greatest_version_number}

--- a/tests/unit/test_jinja_blocks.py
+++ b/tests/unit/test_jinja_blocks.py
@@ -20,11 +20,145 @@ The name of the customer's favorite potato dish.
 {% enddocs %}
 """
 
+no_leading_space = """\
+
+
+{%docs customer_id %}
+The unique key for each customer.
+{% enddocs %}
+"""
+
+no_trailing_space = """\
+
+
+{% docs customer_id%}
+The unique key for each customer.
+{% enddocs %}
+"""
+
+no_spaces = """\
+
+
+{%docs customer_id%}
+The unique key for each customer.
+{% enddocs %}
+"""
+
+no_spaces_end_docs = """\
+
+
+{%docs customer_id%}
+The unique key for each customer.
+{%enddocs%}
+"""
+
+special_character = """\
+
+
+{% docs cust-omer_id %}
+The unique key for each customer.
+{% enddocs %}
+"""
+
+simple_macro = """\
+
+
+{% macro test_macro(name) %}
+  {{ name }}
+{% endmacro %}
+"""
+
+simple_macro_no_spaces = """\
+
+
+{%macro test_macro(name)%}
+  {{ name }}
+{%endmacro%}
+"""
+
+simple_macro_space_to_args = """\
+
+
+{% macro test_macro (name) %}
+  {{ name }}
+{% endmacro %}
+"""
+
+simple_macro_string_defaults = """\
+
+
+{% macro test_macro(name='dave') %}
+  {{ name }}
+{% endmacro %}
+"""
+
+simple_macro_string_defaults_double_quotes = """\
+
+
+{% macro test_macro(name="dave") %}
+  {{ name }}
+{% endmacro %}
+"""
+
+simple_macro_int_defaults = """\
+
+
+{% macro test_macro(num=8) %}
+  {{ num }}
+{% endmacro %}
+"""
+
 
 class TestJinjaBlock:
     def test_from_file_detects_block_range(self):
         range = JinjaBlock.find_block_range(string, "docs", "customer_id")
         assert range == (2, 72)
+
+    def test_from_file_detects_block_range_no_leading_space(self):
+        range = JinjaBlock.find_block_range(no_leading_space, "docs", "customer_id")
+        assert range == (2, 71)
+
+    def test_from_file_detects_block_range_no_trailing_space(self):
+        range = JinjaBlock.find_block_range(no_trailing_space, "docs", "customer_id")
+        assert range == (2, 71)
+
+    def test_from_file_detects_block_range_no_spaces(self):
+        range = JinjaBlock.find_block_range(no_spaces, "docs", "customer_id")
+        assert range == (2, 70)
+
+    def test_from_file_detects_block_range_no_spaces_end_docs(self):
+        range = JinjaBlock.find_block_range(no_spaces_end_docs, "docs", "customer_id")
+        assert range == (2, 68)
+
+    def test_from_file_detects_block_range_special_character(self):
+        range = JinjaBlock.find_block_range(special_character, "docs", "cust-omer_id")
+        assert range == (2, 73)
+
+    def test_from_file_detects_block_range_simple_macro(self):
+        range = JinjaBlock.find_block_range(simple_macro, "macro", "test_macro")
+        assert range == (2, 58)
+
+    def test_from_file_detects_block_range_simple_macro_no_spaces(self):
+        range = JinjaBlock.find_block_range(simple_macro_no_spaces, "macro", "test_macro")
+        assert range == (2, 54)
+
+    def test_from_file_detects_block_range_simple_macro_space_to_args(self):
+        range = JinjaBlock.find_block_range(simple_macro_space_to_args, "macro", "test_macro")
+        assert range == (2, 59)
+
+    def test_from_file_detects_block_range_simple_macro_string_defaults(self):
+        range = JinjaBlock.find_block_range(simple_macro_string_defaults, "macro", "test_macro")
+        assert range == (2, 65)
+
+    def test_from_file_detects_block_range_simple_macro_string_defaults_double_quotes(self):
+        range = JinjaBlock.find_block_range(
+            simple_macro_string_defaults_double_quotes, "macro", "test_macro"
+        )
+        assert range == (2, 65)
+
+    def test_from_file_detects_block_range_simple_macro_int_defaults(self):
+        range = JinjaBlock.find_block_range(simple_macro_int_defaults, "macro", "test_macro")
+        assert range == (2, 58)
 
     def test_from_file_extracts_content(self):
         content = JinjaBlock.isolate_content(string, 2, 72)


### PR DESCRIPTION
closes #205 

Some users saw issues when we collected jinja blocks due to a few shortcomings of our regex matching for jinja blocks, namely:

1. spaces on either side of the start/end lines of the jinja blocks `{%docs my_docs %}` vs `{% docs my_docs %}`
2. special characters in docs names

The fix for problem 1 was fairly straightforward, just updating our space matches to be `zero or more`. In testing, i also found we were lacking support for default values that included quote characters. 

I didn't make any adjustments for special characters, but did add a test for a block name with a special character, and it seemed to pass. Happy to change that if this test is insufficient!