### PR TITLE
Fix for custom generic tests

### DIFF
--- a/dbt_meshify/dbt_projects.py
+++ b/dbt_meshify/dbt_projects.py
@@ -340,8 +340,7 @@ class DbtProject(BaseDbtProject, PathedProject):
                 else ["tests"]
             ):
                 block_type = "test"
-                index = len(top_level_folder)
-                name = macro.name[index:]
+                name = macro.name[5:]
 
             blocks[unique_id] = JinjaBlock.from_file(
                 path=self.path / macro.original_file_path, block_type=block_type, name=name

--- a/dbt_meshify/dbt_projects.py
+++ b/dbt_meshify/dbt_projects.py
@@ -330,11 +330,18 @@ class DbtProject(BaseDbtProject, PathedProject):
         for unique_id, macro in self.manifest.macros.items():
             block_type = "macro"
             name = macro.name
+            top_level_folder = macro.path.split("/")[0]
+
             if macro.package_name != self.name:
                 continue
-            if "tests/generic/" in macro.path:
+            if (
+                top_level_folder in self.project.test_paths
+                if self.project.test_paths
+                else ["tests"]
+            ):
                 block_type = "test"
-                name = macro.name[5:]
+                index = len(top_level_folder)
+                name = macro.name[index:]
 
             blocks[unique_id] = JinjaBlock.from_file(
                 path=self.path / macro.original_file_path, block_type=block_type, name=name

--- a/dbt_meshify/dbt_projects.py
+++ b/dbt_meshify/dbt_projects.py
@@ -140,7 +140,7 @@ class BaseDbtProject:
             return self._models
 
         self._models = {
-            node_name: node
+            node_name: node  # type: ignore
             for node_name, node in self.manifest.nodes.items()
             if node.resource_type == "model" and isinstance(node, ModelNode)
         }
@@ -328,11 +328,16 @@ class DbtProject(BaseDbtProject, PathedProject):
             )
 
         for unique_id, macro in self.manifest.macros.items():
+            block_type = "macro"
+            name = macro.name
             if macro.package_name != self.name:
                 continue
+            if "tests/generic/" in macro.path:
+                block_type = "test"
+                name = macro.name[5:]
 
             blocks[unique_id] = JinjaBlock.from_file(
-                path=self.path / macro.original_file_path, block_type="macro", name=macro.name
+                path=self.path / macro.original_file_path, block_type=block_type, name=name
             )
 
         return blocks

--- a/test-projects/split/split_proj/models/marts/__models.yml
+++ b/test-projects/split/split_proj/models/marts/__models.yml
@@ -45,6 +45,7 @@ models:
           expression: count_food_items + count_drink_items = count_items
       - dbt_utils.expression_is_true:
           expression: subtotal_food_items + subtotal_drink_items = subtotal
+      - custom_generic_test
     columns:
       - name: order_id
         description: The unique key of the orders mart.

--- a/test-projects/split/split_proj/tests/generic/custom_generic_test.sql
+++ b/test-projects/split/split_proj/tests/generic/custom_generic_test.sql
@@ -1,3 +1,3 @@
-{% test custom_generic_test() %}
+{% test custom_generic_test(model) %}
   select true where false
 {% endtest %}

--- a/test-projects/split/split_proj/tests/generic/custom_generic_test.sql
+++ b/test-projects/split/split_proj/tests/generic/custom_generic_test.sql
@@ -1,0 +1,3 @@
+{% test custom_generic_test() %}
+  select true where false
+{% endtest %}

--- a/tests/unit/test_jinja_blocks.py
+++ b/tests/unit/test_jinja_blocks.py
@@ -68,6 +68,14 @@ simple_macro = """\
 {% endmacro %}
 """
 
+simple_custom_generic_test = """\
+
+
+{% test my_custom_test(model) %}
+  select * from {{ model }} where false
+{% endtest %}
+"""
+
 simple_macro_no_spaces = """\
 
 
@@ -176,3 +184,7 @@ class TestJinjaBlock:
             content
             == "{% docs potato_name %}\nThe name of the customer's favorite potato dish.\n{% enddocs %}"
         )
+
+    def test_from_file_extracts_custom_generic_test(self):
+        range = JinjaBlock.find_block_range(simple_custom_generic_test, "test", "my_custom_test")
+        assert range == (2, 88)


### PR DESCRIPTION
When someone creates a custom generic test, it gets rendered as a macro in the manifest. this means that when we compile all the macros in the project during startup of the group and split commands, we fail to find the correct test block. 

this PR
- updates the args to the `JinjaBlock.from_file` call to be `test` and trims `test_` (which dbt adds) to find the name of the custom generic test block when the macro path is under `tests/generic/`
- adds a custom generic test to the split project to ensure this logic works!

submitted in partial fulfillment of #210 